### PR TITLE
Add basic CI

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,11 @@
+[alias]
+# Collection of project wide clippy lints. This is done via an alias because
+# clippy doesn't currently allow for specifiying project-wide lints in a
+# configuration file. This is a similar workaround to the ones presented here:
+# <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+# TODO: add support for --all-features
+xclippy = [
+    "clippy", "--all-targets", "--",
+    "-Wclippy::all",
+    "-Wclippy::disallowed_methods",
+]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,87 @@
+name: Rust
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+env:
+  CARGO_TERM_COLOR: always
+  # Disable incremental compilation.
+  #
+  # Incremental compilation is useful as part of an edit-build-test-edit cycle,
+  # as it lets the compiler avoid recompiling code that hasn't changed. However,
+  # on CI, we're not making small edits; we're almost always building the entire
+  # project from scratch. Thus, incremental compilation on CI actually
+  # introduces *additional* overhead to support making future builds
+  # faster...but no future builds will ever occur in any given CI environment.
+  #
+  # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
+  # for details.
+  CARGO_INCREMENTAL: 0
+  # Allow more retries for network requests in cargo (downloading crates) and
+  # rustup (installing toolchains). This should help to reduce flaky CI failures
+  # from transient network timeouts or other issues.
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # Don't emit giant backtraces in the CI logs.
+  RUST_BACKTRACE: short
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+      fail-fast: false
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+      # make sure benches don't bit-rot
+      - name: build benches
+        # TODO: --all-features
+        run: cargo build --benches --release
+      - name: cargo test
+        # TODO: --all-features
+        run: |
+          cargo nextest run --release
+      - name: Doctests
+        run: |
+          cargo test --doc
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # See '.cargo/config' for list of enabled/disabled clippy lints
+      - name: cargo clippy
+        run: cargo xclippy -D warnings
+
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check


### PR DESCRIPTION
This adds basic CI :
- running tests & doctests,
- compiling benchmarks,
- linting (rustfmt and clippy)

Until we figure out the CircleCI situation or setup a self-hosted GHA alternative.

Run on my fork [here](https://github.com/huitseeker/neptune/actions/runs/4536885726)