### PR TITLE
Bump ff & group to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,17 @@ resolver = "2"
 
 [dependencies]
 lazy_static = "1.4.0"
-#bellperson = { version = "0.24", default-features = false }
-bellperson = { git = "https://github.com/leonardoalt/bellperson", default-features = false }
+bellperson = { version = "0.24", default-features = false }
 blake2s_simd = "0.5"
 blstrs = { version = "0.6.1", optional = true }
 byteorder = "1"
-ff = "0.12.0"
-generic-array = "0.14.4"
-itertools = { version = "0.8.0" }
 ec-gpu = { version = "0.2.0", optional = true }
 ec-gpu-gen = { version = "0.5.2", optional = true }
-#pasta_curves = { version = "0.5.1", features = ["serde"], package = "fil_pasta_curves" }
-#pasta_curves = { path = "../fil_pasta_curves", features = ["serde"], package = "fil_pasta_curves" }
-pasta_curves = { git = "https://github.com/leonardoalt/fil_pasta_curves/", features = ["serde"], package = "fil_pasta_curves" }
+ff = "0.13"
+generic-array = "0.14.6"
+itertools = { version = "0.8.2" }
+log = "0.4.17"
+pasta_curves = { version = "0.5", features = ["serde"] }
 trait-set = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 
@@ -37,8 +35,8 @@ sha2 = "0.9"
 [build-dependencies]
 blstrs = "0.6.1"
 ec-gpu = { version = "0.2.0", optional = true }
-ec-gpu-gen = { version = "0.5.0", optional = true }
-pasta_curves = { version = "0.5.0", features = ["serde"] }
+ec-gpu-gen = { version = "0.5.2", optional = true }
+pasta_curves = { version = "0.5", features = ["serde"] }
 
 [[bench]]
 name = "hash"
@@ -74,3 +72,11 @@ pasta = ["pasta_curves/gpu"]
 members = [
   "gbench",
 ]
+
+[patch.crates-io]
+## DO NOT COMMIT
+bellperson =  {git = "https://github.com/huitseeker/bellperson", branch="update-ff-group" }
+blstrs = { git = "https://github.com/huitseeker/blstrs", branch="WIP-0.13", features = ["__private_bench"] }
+ec-gpu = { git = "https://github.com/filecoin-project/ec-gpu/", branch="upgrade-ff-013" }
+ec-gpu-gen = { git = "https://github.com/filecoin-project/ec-gpu/", branch="upgrade-ff-013" }
+## DO NOT COMMIT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,31 +15,14 @@ bellperson = { git = "https://github.com/leonardoalt/bellperson", default-featur
 blake2s_simd = "0.5"
 blstrs = { version = "0.6.1", optional = true }
 byteorder = "1"
-ec-gpu = { version = "0.2.0", optional = true }
-<<<<<<< HEAD
-ec-gpu-gen = { version = "0.5.2", optional = true }
-ff = "0.12.1"
-generic-array = "0.14.6"
-itertools = { version = "0.8.2" }
-log = "0.4.17"
-pasta_curves = { version = "0.5.2", features = ["serde"], package = "fil_pasta_curves" }
-||||||| parent of cb2b839 (bump_ff)
-ec-gpu-gen = { version = "0.5.0", optional = true }
 ff = "0.12.0"
 generic-array = "0.14.4"
 itertools = { version = "0.8.0" }
-log = "0.4.8"
-pasta_curves = { version = "0.5.1", features = ["serde"], package = "fil_pasta_curves" }
-=======
-ec-gpu-gen = { version = "0.5.0", optional = true }
-ff = "0.13.0"
-generic-array = "0.14.4"
-itertools = { version = "0.8.0" }
-log = "0.4.8"
+ec-gpu = { version = "0.2.0", optional = true }
+ec-gpu-gen = { version = "0.5.2", optional = true }
 #pasta_curves = { version = "0.5.1", features = ["serde"], package = "fil_pasta_curves" }
 #pasta_curves = { path = "../fil_pasta_curves", features = ["serde"], package = "fil_pasta_curves" }
 pasta_curves = { git = "https://github.com/leonardoalt/fil_pasta_curves/", features = ["serde"], package = "fil_pasta_curves" }
->>>>>>> cb2b839 (bump_ff)
 trait-set = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 
@@ -55,9 +38,7 @@ sha2 = "0.9"
 blstrs = "0.6.1"
 ec-gpu = { version = "0.2.0", optional = true }
 ec-gpu-gen = { version = "0.5.0", optional = true }
-#pasta_curves = { version = "0.5.1", package = "fil_pasta_curves" }
-#pasta_curves = { path = "../fil_pasta_curves", features = ["serde"], package = "fil_pasta_curves" }
-pasta_curves = { git = "https://github.com/leonardoalt/fil_pasta_curves/", features = ["serde"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.0", features = ["serde"] }
 
 [[bench]]
 name = "hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/lurk-lab/neptune"
 resolver = "2"
 
 [dependencies]
-lazy_static = "1.4.0"
 bellperson = { version = "0.24", default-features = false }
 blake2s_simd = "0.5"
 blstrs = { version = "0.6.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ repository = "https://github.com/lurk-lab/neptune"
 resolver = "2"
 
 [dependencies]
-bellperson = { version = "0.24", default-features = false }
+bellperson = { version = "0.25", default-features = false }
 blake2s_simd = "0.5"
-blstrs = { version = "0.6.1", optional = true }
+blstrs = { version = "0.7.0", optional = true }
 byteorder = "1"
 ec-gpu = { version = "0.2.0", optional = true }
-ec-gpu-gen = { version = "0.5.2", optional = true }
-ff = "0.13"
+ec-gpu-gen = { version = "0.6.0", optional = true }
+ff = "0.13.0"
 generic-array = "0.14.6"
 itertools = { version = "0.8.2" }
 log = "0.4.17"
@@ -24,7 +24,7 @@ trait-set = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
-blstrs = "0.6.1"
+blstrs = "0.7.0"
 criterion = "0.4.0"
 rand = "0.8.5"
 rand_xorshift = "0.3.0"
@@ -32,9 +32,9 @@ serde_json = "1.0.94"
 sha2 = "0.9"
 
 [build-dependencies]
-blstrs = "0.6.1"
+blstrs = "0.7.0"
 ec-gpu = { version = "0.2.0", optional = true }
-ec-gpu-gen = { version = "0.5.2", optional = true }
+ec-gpu-gen = { version = "0.6.0", optional = true }
 pasta_curves = { version = "0.5", features = ["serde"] }
 
 [[bench]]
@@ -71,11 +71,3 @@ pasta = ["pasta_curves/gpu"]
 members = [
   "gbench",
 ]
-
-[patch.crates-io]
-## DO NOT COMMIT
-bellperson =  {git = "https://github.com/huitseeker/bellperson", branch="update-ff-group" }
-blstrs = { git = "https://github.com/huitseeker/blstrs", branch="WIP-0.13", features = ["__private_bench"] }
-ec-gpu = { git = "https://github.com/filecoin-project/ec-gpu/", branch="upgrade-ff-013" }
-ec-gpu-gen = { git = "https://github.com/filecoin-project/ec-gpu/", branch="upgrade-ff-013" }
-## DO NOT COMMIT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,36 @@ resolver = "2"
 
 [dependencies]
 lazy_static = "1.4.0"
-bellperson = { version = "0.24", default-features = false }
+#bellperson = { version = "0.24", default-features = false }
+bellperson = { git = "https://github.com/leonardoalt/bellperson", default-features = false }
 blake2s_simd = "0.5"
 blstrs = { version = "0.6.1", optional = true }
 byteorder = "1"
 ec-gpu = { version = "0.2.0", optional = true }
+<<<<<<< HEAD
 ec-gpu-gen = { version = "0.5.2", optional = true }
 ff = "0.12.1"
 generic-array = "0.14.6"
 itertools = { version = "0.8.2" }
 log = "0.4.17"
 pasta_curves = { version = "0.5.2", features = ["serde"], package = "fil_pasta_curves" }
+||||||| parent of cb2b839 (bump_ff)
+ec-gpu-gen = { version = "0.5.0", optional = true }
+ff = "0.12.0"
+generic-array = "0.14.4"
+itertools = { version = "0.8.0" }
+log = "0.4.8"
+pasta_curves = { version = "0.5.1", features = ["serde"], package = "fil_pasta_curves" }
+=======
+ec-gpu-gen = { version = "0.5.0", optional = true }
+ff = "0.13.0"
+generic-array = "0.14.4"
+itertools = { version = "0.8.0" }
+log = "0.4.8"
+#pasta_curves = { version = "0.5.1", features = ["serde"], package = "fil_pasta_curves" }
+#pasta_curves = { path = "../fil_pasta_curves", features = ["serde"], package = "fil_pasta_curves" }
+pasta_curves = { git = "https://github.com/leonardoalt/fil_pasta_curves/", features = ["serde"], package = "fil_pasta_curves" }
+>>>>>>> cb2b839 (bump_ff)
 trait-set = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 
@@ -35,8 +54,10 @@ sha2 = "0.9"
 [build-dependencies]
 blstrs = "0.6.1"
 ec-gpu = { version = "0.2.0", optional = true }
-ec-gpu-gen = { version = "0.5.2", optional = true }
-pasta_curves = { version = "0.5.2", package = "fil_pasta_curves" }
+ec-gpu-gen = { version = "0.5.0", optional = true }
+#pasta_curves = { version = "0.5.1", package = "fil_pasta_curves" }
+#pasta_curves = { path = "../fil_pasta_curves", features = ["serde"], package = "fil_pasta_curves" }
+pasta_curves = { git = "https://github.com/leonardoalt/fil_pasta_curves/", features = ["serde"], package = "fil_pasta_curves" }
 
 [[bench]]
 name = "hash"

--- a/benches/hash.rs
+++ b/benches/hash.rs
@@ -150,7 +150,7 @@ where
 
     let mut group = c.benchmark_group(format!("arity-{}", arity));
 
-    let preimage = vec![Fr::one(); arity];
+    let preimage = vec![Fr::ONE; arity];
     let consts = PoseidonConstants::<Fr, A>::new();
     group.bench_function("bls", |b| {
         b.iter(|| Poseidon::new_with_preimage(&preimage, &consts).hash())

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-lazy_static = "1.4.0"
 bellperson = { version = "0.24.1", default-features = false }
 blake2s_simd = "0.5"
 byteorder = "1"

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -7,19 +7,19 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bellperson = { version = "0.24.1", default-features = false }
+bellperson = { version = "0.25.0", default-features = false }
 blake2s_simd = "0.5"
 byteorder = "1"
 env_logger = "0.7.1"
-ff = "0.13"
+ff = "0.13.0"
 generic-array = "0.14.6"
 log = "0.4.17"
 neptune = { path = "../", default-features = false, features = ["arity8", "arity11", "bls", "pasta"] }
 structopt = { version = "0.3", default-features = false }
-blstrs = { version = "0.6.1", features = ["gpu"] }
-pasta_curves = { version = "0.5", features = ["serde"] }
+blstrs = { version = "0.7.0", features = ["gpu"] }
+pasta_curves = { version = "0.5.1", features = ["gpu"]}
 ec-gpu = "0.2.0"
-ec-gpu-gen = "0.5.2"
+ec-gpu-gen = "0.6.0"
 
 [features]
 default = ["opencl"]

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -12,13 +12,13 @@ bellperson = { version = "0.24.1", default-features = false }
 blake2s_simd = "0.5"
 byteorder = "1"
 env_logger = "0.7.1"
-ff = "0.12.1"
+ff = "0.13"
 generic-array = "0.14.6"
 log = "0.4.17"
 neptune = { path = "../", default-features = false, features = ["arity8", "arity11", "bls", "pasta"] }
 structopt = { version = "0.3", default-features = false }
 blstrs = { version = "0.6.1", features = ["gpu"] }
-pasta_curves = { version = "0.5.2", features = ["gpu"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5", features = ["serde"] }
 ec-gpu = "0.2.0"
 ec-gpu-gen = "0.5.2"
 

--- a/gbench/src/main.rs
+++ b/gbench/src/main.rs
@@ -31,7 +31,7 @@ fn bench_column_building<F: PrimeField + GpuName>(
     info!("{}: ColumnTreeBuilder created", log_prefix);
 
     // Simplify computing the expected root.
-    let constant_element = F::zero();
+    let constant_element = F::ZERO;
     let constant_column = GenericArray::<F, U11>::generate(|_| constant_element);
 
     let max_batch_size = if let Some(batcher) = &builder.column_batcher {

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -83,7 +83,7 @@ impl<Scalar: PrimeField> Elt<Scalar> {
                 if enforce {
                     cs.enforce(
                         || "enforce num allocation preserves lc".to_string(),
-                        |_| num.lc(Scalar::one()),
+                        |_| num.lc(Scalar::ONE),
                         |lc| lc + CS::one(),
                         |lc| lc + v.get_variable(),
                     );
@@ -102,7 +102,7 @@ impl<Scalar: PrimeField> Elt<Scalar> {
 
     fn lc(&self) -> LinearCombination<Scalar> {
         match self {
-            Self::Num(num) => num.lc(Scalar::one()),
+            Self::Num(num) => num.lc(Scalar::ONE),
             Self::Allocated(v) => LinearCombination::<Scalar>::zero() + v.get_variable(),
         }
     }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -683,7 +683,7 @@ mod tests {
             };
             let mut i = 0;
 
-            let mut fr_data = vec![Fr::zero(); preimage_length];
+            let mut fr_data = vec![Fr::ZERO; preimage_length];
             let data: Vec<AllocatedNum<Fr>> = (0..preimage_length)
                 .enumerate()
                 .map(|_| {

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -55,7 +55,7 @@ impl<Scalar: PrimeField> Elt<Scalar> {
                 if enforce {
                     cs.enforce(
                         || "enforce num allocation preserves lc".to_string(),
-                        |_| num.lc(Scalar::one()),
+                        |_| num.lc(Scalar::ONE),
                         |lc| lc + CS::one(),
                         |lc| lc + v.get_variable(),
                     );
@@ -74,7 +74,7 @@ impl<Scalar: PrimeField> Elt<Scalar> {
 
     pub fn lc(&self) -> LinearCombination<Scalar> {
         match self {
-            Self::Num(num) => num.lc(Scalar::one()),
+            Self::Num(num) => num.lc(Scalar::ONE),
             Self::Allocated(v) => LinearCombination::<Scalar>::zero() + v.get_variable(),
         }
     }
@@ -119,8 +119,8 @@ impl<Scalar: PrimeField> Elt<Scalar> {
                     AllocatedNum::alloc(&mut cs.namespace(|| "squared num"), || Ok(tmp))?;
                 cs.enforce(
                     || "squaring constraint",
-                    |_| num.lc(Scalar::one()),
-                    |_| num.lc(Scalar::one()),
+                    |_| num.lc(Scalar::ONE),
+                    |_| num.lc(Scalar::ONE),
                     |lc| lc + allocated.get_variable(),
                 );
                 Ok(allocated)
@@ -225,7 +225,7 @@ where
         match self.constants.hash_type {
             HashType::ConstantLength(_) | HashType::Encryption => {
                 for elt in self.elements[self.pos..].iter_mut() {
-                    *elt = Elt::num_from_fr::<CS>(Scalar::zero());
+                    *elt = Elt::num_from_fr::<CS>(Scalar::ZERO);
                 }
                 self.pos = self.elements.len();
             }
@@ -413,7 +413,7 @@ where
     }
 
     fn initial_elements<CS: ConstraintSystem<Scalar>>() -> Vec<Elt<Scalar>> {
-        std::iter::repeat(Elt::num_from_fr::<CS>(Scalar::zero()))
+        std::iter::repeat(Elt::num_from_fr::<CS>(Scalar::ZERO))
             .take(A::to_usize() + 1)
             .collect()
     }

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -774,7 +774,7 @@ mod tests {
 
             {
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let mut fr_data = vec![Fr::zero(); preimage_length];
+                let mut fr_data = vec![Fr::ZERO; preimage_length];
                 let data: Vec<AllocatedNum<Fr>> = data(&mut cs, &mut fr_data);
 
                 let out = poseidon_hash_allocated(&mut cs, data.clone(), &constants)
@@ -809,7 +809,7 @@ mod tests {
 
             {
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let mut fr_data = vec![Fr::zero(); preimage_length];
+                let mut fr_data = vec![Fr::ZERO; preimage_length];
                 let data: Vec<AllocatedNum<Fr>> = data(&mut cs, &mut fr_data);
 
                 let out =

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -144,7 +144,11 @@ where
     }
 }
 
-#[cfg(all(any(feature = "cuda", feature = "opencl"), not(target_os = "macos")))]
+#[cfg(all(
+    feature = "bls",
+    any(feature = "cuda", feature = "opencl"),
+    not(target_os = "macos")
+))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -81,7 +81,7 @@ where
 
     fn reset(&mut self) {
         self.fill_index = 0;
-        self.data.iter_mut().for_each(|place| *place = F::zero());
+        self.data.iter_mut().for_each(|place| *place = F::ZERO);
     }
 }
 fn as_generic_arrays<A: Arity<F>, F: PrimeField>(vec: &[F]) -> &[GenericArray<F, A>] {
@@ -117,7 +117,7 @@ where
 
         let builder = Self {
             leaf_count,
-            data: vec![F::zero(); leaf_count],
+            data: vec![F::ZERO; leaf_count],
             fill_index: 0,
             column_constants: PoseidonConstants::<F, ColumnArity>::new(),
             column_batcher,
@@ -186,7 +186,7 @@ mod tests {
             ColumnTreeBuilder::<Fr, U11, U8>::new(column_batcher, tree_batcher, leaves).unwrap();
 
         // Simplify computing the expected root.
-        let constant_element = Fr::zero();
+        let constant_element = Fr::ZERO;
         let constant_column = GenericArray::<Fr, U11>::generate(|_| constant_element);
 
         let max_batch_size = if let Some(batcher) = &builder.column_batcher {

--- a/src/hash_type.rs
+++ b/src/hash_type.rs
@@ -48,7 +48,7 @@ impl<F: PrimeField, A: Arity<F>> HashType<F, A> {
             // NOTE: in order to leave room for future `Strength` tags,
             // we make identifier a multiple of 2^40 rather than 2^32.
             HashType::Custom(ref ctype) => ctype.domain_tag(),
-            HashType::Sponge => F::zero(),
+            HashType::Sponge => F::ZERO,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
-#[macro_use]
-extern crate lazy_static;
 
 pub use crate::poseidon::{Arity, Poseidon};
 use crate::round_constants::generate_constants;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -79,7 +79,7 @@ pub fn mat_mul<F: PrimeField>(a: &Matrix<F>, b: &Matrix<F>) -> Option<Matrix<F>>
 }
 
 fn vec_mul<F: PrimeField>(a: &[F], b: &[F]) -> F {
-    a.iter().zip(b).fold(F::zero(), |mut acc, (v1, v2)| {
+    a.iter().zip(b).fold(F::ZERO, |mut acc, (v1, v2)| {
         let mut tmp = *v1;
         tmp.mul_assign(v2);
         acc.add_assign(&tmp);
@@ -118,7 +118,7 @@ pub fn left_apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F> {
         "Matrix can only be applied to vector of same size."
     );
 
-    let mut result = vec![F::zero(); v.len()];
+    let mut result = vec![F::ZERO; v.len()];
 
     for (result, row) in result.iter_mut().zip(m.iter()) {
         for (mat_val, vec_val) in row.iter().zip(v) {
@@ -139,7 +139,7 @@ pub fn apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F> {
         "Matrix can only be applied to vector of same size."
     );
 
-    let mut result = vec![F::zero(); v.len()];
+    let mut result = vec![F::ZERO; v.len()];
     for (j, val) in result.iter_mut().enumerate() {
         for (i, row) in m.iter().enumerate() {
             let mut tmp = row[j];
@@ -167,18 +167,18 @@ pub fn transpose<F: PrimeField>(matrix: &Matrix<F>) -> Matrix<F> {
 
 #[allow(clippy::needless_range_loop)]
 pub fn make_identity<F: PrimeField>(size: usize) -> Matrix<F> {
-    let mut result = vec![vec![F::zero(); size]; size];
+    let mut result = vec![vec![F::ZERO; size]; size];
     for i in 0..size {
-        result[i][i] = F::one();
+        result[i][i] = F::ONE;
     }
     result
 }
 
 pub fn kronecker_delta<F: PrimeField>(i: usize, j: usize) -> F {
     if i == j {
-        F::one()
+        F::ONE
     } else {
-        F::zero()
+        F::ZERO
     }
 }
 
@@ -227,7 +227,7 @@ fn eliminate<F: PrimeField>(
     column: usize,
     shadow: &mut Matrix<F>,
 ) -> Option<Matrix<F>> {
-    let zero = F::zero();
+    let zero = F::ZERO;
     let pivot_index = (0..rows(matrix))
         .find(|&i| matrix[i][column] != zero && (0..column).all(|j| matrix[i][j] == zero))?;
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -562,7 +562,7 @@ mod tests {
                 1,
                 res.unwrap()
                     .iter()
-                    .filter(|&row| row[i] != Fr::zero())
+                    .filter(|&row| row[i] != Fr::ZERO)
                     .count()
             );
         }

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -157,12 +157,12 @@ fn make_prime<F: PrimeField>(m: &Matrix<F>) -> Matrix<F> {
         .enumerate()
         .map(|(i, row)| match i {
             0 => {
-                let mut new_row = vec![F::zero(); row.len()];
-                new_row[0] = F::one();
+                let mut new_row = vec![F::ZERO; row.len()];
+                new_row[0] = F::ONE;
                 new_row
             }
             _ => {
-                let mut new_row = vec![F::zero(); row.len()];
+                let mut new_row = vec![F::ZERO; row.len()];
                 new_row[1..].copy_from_slice(&row[1..]);
                 new_row
             }
@@ -184,9 +184,9 @@ fn make_double_prime<F: PrimeField>(m: &Matrix<F>, m_hat_inv: &Matrix<F>) -> Mat
                 new_row
             }
             _ => {
-                let mut new_row = vec![F::zero(); row.len()];
+                let mut new_row = vec![F::ZERO; row.len()];
                 new_row[0] = w_hat[i - 1];
-                new_row[i] = F::one();
+                new_row[i] = F::ONE;
                 new_row
             }
         })

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -361,6 +361,7 @@ where
     /// use neptune::poseidon::PoseidonConstants;
     /// use neptune::poseidon::Poseidon;
     /// use pasta_curves::Fp;
+    /// use ff::Field;
     /// use generic_array::typenum::U8;
     ///
     /// let constants: PoseidonConstants<Fp, U8> = PoseidonConstants::new();
@@ -399,6 +400,7 @@ where
     /// use neptune::poseidon::PoseidonConstants;
     /// use neptune::poseidon::Poseidon;
     /// use pasta_curves::Fp;
+    /// use ff::Field;
     /// use generic_array::typenum::U2;
     ///
     /// let preimage_set_length = 1;
@@ -468,6 +470,7 @@ where
     /// use neptune::poseidon::PoseidonConstants;
     /// use neptune::poseidon::Poseidon;
     /// use pasta_curves::Fp;
+    /// use ff::Field;
     /// use generic_array::typenum::U2;
     ///
     /// let constants: PoseidonConstants<Fp, U2> = PoseidonConstants::new_constant_length(1);
@@ -514,6 +517,7 @@ where
     /// use neptune::poseidon::PoseidonConstants;
     /// use neptune::poseidon::Poseidon;
     /// use pasta_curves::Fp;
+    /// use ff::Field;
     /// use generic_array::typenum::U2;
     ///
     /// let constants: PoseidonConstants<Fp, U2> = PoseidonConstants::new_constant_length(1);
@@ -561,6 +565,7 @@ where
     /// use neptune::poseidon::{HashMode, PoseidonConstants};
     /// use neptune::poseidon::Poseidon;
     /// use pasta_curves::Fp;
+    /// use ff::Field;
     /// use generic_array::typenum::U2;
     ///
     /// let constants: PoseidonConstants<Fp, U2> = PoseidonConstants::new();
@@ -593,6 +598,7 @@ where
     /// use neptune::poseidon::PoseidonConstants;
     /// use neptune::poseidon::Poseidon;
     /// use pasta_curves::Fp;
+    /// use ff::Field;
     /// use generic_array::typenum::U2;
     ///
     /// let constants: PoseidonConstants<Fp, U2> = PoseidonConstants::new();
@@ -641,6 +647,7 @@ where
     /// use neptune::poseidon::PoseidonConstants;
     /// use neptune::poseidon::Poseidon;
     /// use pasta_curves::Fp;
+    /// use ff::Field;
     /// use generic_array::typenum::U2;
     ///
     /// let constants: PoseidonConstants<Fp, U2> = PoseidonConstants::new();
@@ -676,6 +683,7 @@ where
     /// use neptune::poseidon::PoseidonConstants;
     /// use neptune::poseidon::Poseidon;
     /// use pasta_curves::Fp;
+    /// use ff::Field;
     /// use generic_array::typenum::U2;
     ///
     /// let constants: PoseidonConstants<Fp, U2> = PoseidonConstants::new();

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -368,7 +368,7 @@ where
     ///
     /// assert_eq!(poseidon.elements.len(), 9);
     /// for index in 1..9 {
-    ///     assert_eq!(poseidon.elements[index], Fp::zero());
+    ///     assert_eq!(poseidon.elements[index], Fp::ZERO);
     /// }
     /// ```
     pub fn new(constants: &'a PoseidonConstants<F, A>) -> Self {
@@ -411,7 +411,7 @@ where
     /// assert_eq!(constants.width(), 3);
     /// assert_eq!(poseidon.elements.len(), constants.width());
     /// assert_eq!(poseidon.elements[1], Fp::from(u64::MAX));
-    /// assert_eq!(poseidon.elements[2], Fp::zero());
+    /// assert_eq!(poseidon.elements[2], Fp::ZERO);
     /// ```
     pub fn new_with_preimage(preimage: &[F], constants: &'a PoseidonConstants<F, A>) -> Self {
         let elements = match constants.hash_type {
@@ -477,7 +477,7 @@ where
     ///
     /// assert_eq!(poseidon.elements.len(), constants.width());
     /// assert_eq!(poseidon.elements[1], Fp::from(u64::MAX));
-    /// assert_eq!(poseidon.elements[2], Fp::zero());
+    /// assert_eq!(poseidon.elements[2], Fp::ZERO);
     ///
     /// let preimage = vec![Fp::from(u64::MIN), Fp::from(u64::MIN)];
     /// poseidon.set_preimage(&preimage);
@@ -520,14 +520,14 @@ where
     ///
     /// let mut poseidon = Poseidon::<Fp, U2>::new(&constants);
     /// assert_eq!(poseidon.elements.len(), constants.width());
-    /// assert_eq!(poseidon.elements[1], Fp::zero());
-    /// assert_eq!(poseidon.elements[2], Fp::zero());
+    /// assert_eq!(poseidon.elements[1], Fp::ZERO);
+    /// assert_eq!(poseidon.elements[2], Fp::ZERO);
     ///
     /// let pos = poseidon.input(Fp::from(u64::MAX)).expect("can't add one more element");
     ///
     /// assert_eq!(pos, 1);
     /// assert_eq!(poseidon.elements[1], Fp::from(u64::MAX));
-    /// assert_eq!(poseidon.elements[2], Fp::zero());
+    /// assert_eq!(poseidon.elements[2], Fp::ZERO);
     ///
     /// let pos = poseidon.input(Fp::from(u64::MAX)).expect("can't add one more element");
     ///
@@ -571,7 +571,7 @@ where
     ///
     /// let digest = poseidon.hash_in_mode(HashMode::Correct);
     ///
-    /// assert_ne!(digest, Fp::zero()); // digest has `Fp` type
+    /// assert_ne!(digest, Fp::ZERO); // digest has `Fp` type
     /// ```
     pub fn hash_in_mode(&mut self, mode: HashMode) -> F {
         let res = match mode {
@@ -603,7 +603,7 @@ where
     ///
     /// let digest = poseidon.hash();
     ///
-    /// assert_ne!(digest, Fp::zero()); // digest has `Fp` type
+    /// assert_ne!(digest, Fp::ZERO); // digest has `Fp` type
     /// ```
     pub fn hash(&mut self) -> F {
         self.hash_in_mode(DEFAULT_HASH_MODE)
@@ -686,7 +686,7 @@ where
     ///
     /// let digest = poseidon.hash_optimized_static();
     ///
-    /// assert_ne!(digest, Fp::zero()); // digest has `Fp` type
+    /// assert_ne!(digest, Fp::ZERO); // digest has `Fp` type
     /// ```
     pub fn hash_optimized_static(&mut self) -> F {
         // The first full round should use the initial constants.
@@ -916,7 +916,7 @@ mod tests {
     #[test]
     fn reset() {
         let test_arity = 2;
-        let preimage = vec![<Fr as Field>::one(); test_arity];
+        let preimage = vec![<Fr as Field>::ONE; test_arity];
         let constants = PoseidonConstants::new();
         let mut h = Poseidon::<Fr, U2>::new_with_preimage(&preimage, &constants);
         h.hash();
@@ -931,9 +931,9 @@ mod tests {
     #[test]
     fn hash_det() {
         let test_arity = 2;
-        let mut preimage = vec![Fr::zero(); test_arity];
+        let mut preimage = vec![Fr::ZERO; test_arity];
         let constants = PoseidonConstants::new();
-        preimage[0] = <Fr as Field>::one();
+        preimage[0] = <Fr as Field>::ONE;
 
         let mut h = Poseidon::<Fr, U2>::new_with_preimage(&preimage, &constants);
 
@@ -945,9 +945,9 @@ mod tests {
 
     #[test]
     fn hash_arity_3() {
-        let mut preimage = [Fr::zero(); 3];
+        let mut preimage = [Fr::ZERO; 3];
         let constants = PoseidonConstants::new();
-        preimage[0] = <Fr as Field>::one();
+        preimage[0] = <Fr as Field>::ONE;
 
         let mut h = Poseidon::<Fr, typenum::U3>::new_with_preimage(&preimage, &constants);
 

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -376,7 +376,7 @@ where
             if i == 0 {
                 constants.domain_tag
             } else {
-                F::zero()
+                F::ZERO
             }
         });
         Poseidon {
@@ -422,7 +422,7 @@ where
                     if i == 0 {
                         constants.domain_tag
                     } else if i > preimage.len() {
-                        F::zero()
+                        F::ZERO
                     } else {
                         preimage[i - 1]
                     }
@@ -494,7 +494,7 @@ where
     /// Restore the initial state
     pub fn reset(&mut self) {
         self.reset_offsets();
-        self.elements[1..].iter_mut().for_each(|l| *l = F::zero());
+        self.elements[1..].iter_mut().for_each(|l| *l = F::ZERO);
         self.elements[0] = self.constants.domain_tag;
     }
 
@@ -621,7 +621,7 @@ where
         match self.constants.hash_type {
             HashType::ConstantLength(_) | HashType::Encryption => {
                 for elt in self.elements[self.pos..].iter_mut() {
-                    *elt = F::zero();
+                    *elt = F::ZERO;
                 }
                 self.pos = self.elements.len();
             }
@@ -819,7 +819,7 @@ where
     /// exploits the fact that our MDS matrices are symmetric by construction.
     #[allow(clippy::ptr_arg)]
     pub(crate) fn product_mds_with_matrix(&mut self, matrix: &Matrix<F>) {
-        let mut result = GenericArray::<F, A::ConstantsSize>::generate(|_| F::zero());
+        let mut result = GenericArray::<F, A::ConstantsSize>::generate(|_| F::ZERO);
 
         for (j, val) in result.iter_mut().enumerate() {
             for (i, row) in matrix.iter().enumerate() {
@@ -834,7 +834,7 @@ where
 
     // Sparse matrix in this context means one of the form, M''.
     fn product_mds_with_sparse_matrix(&mut self, sparse_matrix: &SparseMatrix<F>) {
-        let mut result = GenericArray::<F, A::ConstantsSize>::generate(|_| F::zero());
+        let mut result = GenericArray::<F, A::ConstantsSize>::generate(|_| F::ZERO);
 
         // First column is dense.
         for (i, val) in sparse_matrix.w_hat.iter().enumerate() {

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -64,7 +64,7 @@ pub(crate) fn compress_round_constants<F: PrimeField>(
             let mut inverted = apply_matrix(inverse_matrix, &acc);
 
             partial_keys.push(inverted[0]);
-            inverted[0] = F::zero();
+            inverted[0] = F::ZERO;
 
             vec_add(previous_round_keys, &inverted)
         });
@@ -92,7 +92,7 @@ pub(crate) fn compress_round_constants<F: PrimeField>(
         let pk = inv[0];
 
         // M^-1(T) - pk (kinda)
-        inv[0] = F::zero();
+        inv[0] = F::ZERO;
 
         // (M^-1(T) - pk) - I
         let result_key = vec_add(initial_round_keys, &inv);
@@ -108,7 +108,7 @@ pub(crate) fn compress_round_constants<F: PrimeField>(
         ////////////////////////////////////////////////////////////////////////////////
         // Shared between branches, arbitrary initial state representing the output of a previous round's S-Box layer.
         // X
-        let initial_state = vec![F::one(); width];
+        let initial_state = vec![F::ONE; width];
 
         ////////////////////////////////////////////////////////////////////////////////
         // Compute one step with the given (unpreprocessed) constants.

--- a/src/proteus/gpu.rs
+++ b/src/proteus/gpu.rs
@@ -190,7 +190,7 @@ where
                 .arg(&(preimages.len() as i32))
                 .run()?;
 
-            let mut frs = vec![F::zero(); num_hashes];
+            let mut frs = vec![F::ZERO; num_hashes];
             program.read_into_buffer(&result_buffer, &mut frs)?;
             Ok(frs.to_vec())
         });

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -266,7 +266,7 @@ mod tests {
         let constants = PoseidonConstants::<Fr, U2>::new();
         let constants2 = serde_json::from_slice(&serde_json::to_vec(&constants).unwrap()).unwrap();
         let test_arity = 2;
-        let preimage = vec![<Fr as Field>::one(); test_arity];
+        let preimage = vec![<Fr as Field>::ONE; test_arity];
         let mut h1 = Poseidon::<Fr, U2>::new_with_preimage(&preimage, &constants);
         let mut h2 = Poseidon::<Fr, U2>::new_with_preimage(&preimage, &constants2);
 
@@ -278,7 +278,7 @@ mod tests {
         let constants = PoseidonConstants::<S1, U2>::new();
         let constants2 = serde_json::from_slice(&serde_json::to_vec(&constants).unwrap()).unwrap();
         let test_arity = 2;
-        let preimage = vec![<S1 as Field>::one(); test_arity];
+        let preimage = vec![<S1 as Field>::ONE; test_arity];
         let mut h1 = Poseidon::<S1, U2>::new_with_preimage(&preimage, &constants);
         let mut h2 = Poseidon::<S1, U2>::new_with_preimage(&preimage, &constants2);
 

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -194,7 +194,7 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> InnerSpongeAP
     // Supplemental methods needed for a generic implementation.
 
     fn zero() -> Elt<F> {
-        Elt::num_from_fr::<CS>(F::zero())
+        Elt::num_from_fr::<CS>(F::ZERO)
     }
 
     fn rate(&self) -> usize {
@@ -303,7 +303,7 @@ mod tests {
         assert_eq!(expected_constraints, root_cs.num_constraints());
         // Simple sanity check that results are all non-zero and distinct.
         for (i, elt) in allocated_result.iter().enumerate() {
-            assert!(elt.val().unwrap() != F::zero());
+            assert!(elt.val().unwrap() != F::ZERO);
             // This is expensive (n^2), but it's hard to put field element into a set since we can't hash or compare (except equality).
             for (j, elt2) in allocated_result.iter().enumerate() {
                 if i != j {

--- a/src/sponge/vanilla.rs
+++ b/src/sponge/vanilla.rs
@@ -460,7 +460,7 @@ impl<F: PrimeField, A: Arity<F>> InnerSpongeAPI<F, A> for Sponge<'_, F, A> {
     // Supplemental methods needed for a generic implementation.
 
     fn zero() -> F {
-        F::zero()
+        F::ZERO
     }
 
     fn rate(&self) -> usize {
@@ -535,7 +535,7 @@ mod tests {
 
         // Simple sanity check that are all non-zero and distinct.
         for (i, elt) in result.iter().enumerate() {
-            assert!(*elt != F::zero());
+            assert!(*elt != F::ZERO);
             // This is expensive (n^2), but it's hard to put field element into a set since we can't hash or compare (except equality).
             for (j, elt2) in result.iter().enumerate() {
                 if i != j {

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -243,7 +243,11 @@ where
     }
 }
 
-#[cfg(all(any(feature = "cuda", feature = "opencl"), not(target_os = "macos")))]
+#[cfg(all(
+    feature = "bls",
+    any(feature = "cuda", feature = "opencl"),
+    not(target_os = "macos")
+))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -61,7 +61,7 @@ where
 
     fn reset(&mut self) {
         self.fill_index = 0;
-        self.data.iter_mut().for_each(|place| *place = F::zero());
+        self.data.iter_mut().for_each(|place| *place = F::ZERO);
     }
 }
 
@@ -95,7 +95,7 @@ where
     ) -> Result<Self, Error> {
         let builder = Self {
             leaf_count,
-            data: vec![F::zero(); leaf_count],
+            data: vec![F::ZERO; leaf_count],
             fill_index: 0,
             tree_constants: PoseidonConstants::<F, TreeArity>::new(),
             tree_batcher,
@@ -117,7 +117,7 @@ where
         let intermediate_tree_size = self.tree_size(0) + self.leaf_count;
         let arity = TreeArity::to_usize();
 
-        let mut tree_data = vec![F::zero(); intermediate_tree_size];
+        let mut tree_data = vec![F::ZERO; intermediate_tree_size];
 
         tree_data[0..self.leaf_count].copy_from_slice(&self.data);
 
@@ -282,7 +282,7 @@ mod tests {
             let mut builder = TreeBuilder::<Fr, U8>::new(batcher, leaves, rows_to_discard).unwrap();
 
             // Simplify computing the expected root.
-            let constant_element = Fr::zero();
+            let constant_element = Fr::ZERO;
 
             let effective_batch_size = usize::min(batch_size, max_leaf_batch_size);
 


### PR DESCRIPTION
~~Still testing this, in particular, the rust-gpu-tools import on the cuda / opencl features may have some issues.~~

Edit: solved by upgrading rust-gpu-tools to 0.7.1 in upstream `ec_gpu`.

Depends on https://github.com/filecoin-project/bellperson/pull/304
Fixes #171 

~~Edit(4/14): this needs work on the pasta-fil-curves repo.~~
Edit. (4/15): I'm seeing issues with tree builder tests hanging on opencl. Is this something you're seeing as well @porcuquine ?

**Historical (solved) issue:**
https://gist.github.com/huitseeker/230caa8cd63e049846f95ac0d8c77fe5

```
huitseeker@lightning.local➜~/tmp/neptune(bump_ff_group)» cargo tree -p rust-gpu-tools -i                                                                                                                                             [12:48:10]
warning: patch for `blstrs` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
rust-gpu-tools v0.7.0
└── ec-gpu-gen v0.5.2 (https://github.com/filecoin-project/ec-gpu/?branch=upgrade-ff-013#9616bd3c)
    ├── bellperson v0.24.1 (https://github.com/huitseeker/bellperson?branch=update-ff-group#36a75691)
    │   ├── gbench v0.5.4 (/Users/huitseeker/tmp/neptune/gbench)
    │   └── neptune v8.1.1 (/Users/huitseeker/tmp/neptune)
    │       └── gbench v0.5.4 (/Users/huitseeker/tmp/neptune/gbench)
    ├── gbench v0.5.4 (/Users/huitseeker/tmp/neptune/gbench)
    └── neptune v8.1.1 (/Users/huitseeker/tmp/neptune) (*)
    [build-dependencies]
    ├── bellperson v0.24.1 (https://github.com/huitseeker/bellperson?branch=update-ff-group#36a75691) (*)
    └── neptune v8.1.1 (/Users/huitseeker/tmp/neptune) (*)
    ```