### PR TITLE
chore: make version part of the release commit

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,1 @@
+consolidate-commits = false


### PR DESCRIPTION
The default behaviour of cargo-release changed in v0.25. When there
is a workspace, it now consolidates all changes into a single commit
by default. This means that the commit message can't contain the
version number of a specific crate.

With adding a relase.toml file with the `consolidate-commits = false`
options restores the old behaviour and you get separate commits. We
release those two crates separately anyway.

I decided to use the release.toml file instead of putting it into
the Cargo.toml, to make it clearer that we use custom cargo-release
options. This can easily be overlooked if it's just a value in
the Cargo.toml.

Sister PR of https://github.com/filecoin-project/ec-gpu/pull/45