### PR TITLE
Add self-hosted GPU CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,3 +85,33 @@ jobs:
         with:
           command: fmt
           args: --all --check
+
+  # Runs the test suite on a self-hosted GPU machine with CUDA enabled
+  gpu:
+    runs-on: self-hosted
+    env:
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITITES: compute,utility
+      # The `compute`/`sm` number corresponds to the Nvidia GPU architecture
+      # In this case, the self-hosted machine uses the Ampere architecture
+      # See https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+      EC_GPU_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_86 --generate-code=arch=compute_86,code=sm_86
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - name: Install GPU deps
+        run: |
+          apt-get update
+          apt-get install ocl-icd-opencl-dev --yes
+        # Check we have access to the machine's Nvidia drivers
+      - run: nvidia-smi
+        # Check that CUDA is installed with a driver-compatible version
+        # This must also be compatible with the GPU architecture, see above link
+      - run: nvcc --version
+        # Check that we can access the OpenCL headers
+      - run: clinfo
+      - name: CUDA tests
+        run: |
+          cargo test --no-default-features --features cuda,pasta,bls,arity2,arity4,arity8,arity11,arity16,arity24,arity36
+      

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,7 +87,8 @@ jobs:
           args: --all --check
 
   # Runs the test suite on a self-hosted GPU machine with CUDA enabled
-  gpu:
+  test-cuda:
+    name: Rust tests on CUDA
     runs-on: self-hosted
     env:
       NVIDIA_VISIBLE_DEVICES: all


### PR DESCRIPTION
Closes #180 

The self-hosted runner uses this [Docker container](https://github.com/samuelburnham/hello-docker-action/blob/main/Dockerfile) (which can be upstreamed) as a [systemd service](https://github.com/samuelburnham/hello-docker-action/tree/main/server).

Future work:
- Move the `ocl-icd-opecl-dev` dependency to the Dockerfile
- Test with the `opencl` feature as well
- Upgrade the self-hosted hardware & potentially use it for other CI tests