### PR TITLE
ci: trigger CI on PR add to a merge queue

### DIFF
--- a/.github/workflows/licenses-audits.yml
+++ b/.github/workflows/licenses-audits.yml
@@ -1,6 +1,7 @@
 name: cargo-deny
 
 on:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,7 @@
 name: Rust
 
 on:
+  merge_group:
   push:
     branches:
       - master


### PR DESCRIPTION
See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions