### PR TITLE
Support optimized witness generation for circuit2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/lurk-lab/neptune"
 rust-version = "1.64.0"
 
 [dependencies]
+bellpepper = { workspace = true }
 bellperson = { workspace = true }
 blake2s_simd = { workspace = true }
 blstrs = { workspace = true, optional = true }
@@ -51,7 +52,7 @@ incremental = false
 codegen-units = 1
 
 [features]
-default = ["bellperson/default"]
+default = ["bellpepper/default"]
 cuda = ["ec-gpu-gen/cuda", "ec-gpu", "pasta_curves/gpu"]
 opencl = ["ec-gpu-gen/opencl", "ec-gpu", "pasta_curves/gpu"]
 # The supported arities for Poseidon running on the GPU are specified at compile-time.
@@ -67,6 +68,8 @@ strengthened = []
 # The supported fields for Poseidon running on the GPU are specified at compile-time.
 bls = ["blstrs/gpu"]
 pasta = ["pasta_curves/gpu"]
+# Use bellperson instead of bellpepper.
+bellperson = []
 
 [workspace]
 resolver = "2"
@@ -76,6 +79,7 @@ members = [
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
+bellpepper = "0.1.2"
 bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
 blake2s_simd = "0.5"
 blstrs = { version = "0.7.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ members = [
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
-bellperson = { version = "0.25", default-features = false }
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
 blake2s_simd = "0.5"
 blstrs = { version = "0.7.0" }
 ff = "0.13.0"

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -1,44 +1,56 @@
 use crate::poseidon::{Arity, PoseidonConstants};
 use bellperson::gadgets::num::AllocatedNum;
 use bellperson::util_cs::bench_cs::BenchCS;
-use bellperson::{Circuit, ConstraintSystem, SynthesisError};
+use bellperson::util_cs::witness_cs::WitnessCS;
+use bellperson::{ConstraintSystem, SynthesisError};
 use blstrs::Scalar as Fr;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use ff::Field;
 use generic_array::typenum;
 use neptune::circuit::{poseidon_hash_circuit, CircuitType};
+use neptune::circuit2::poseidon_hash_allocated_mut;
 use neptune::*;
 use rand::thread_rng;
 use std::marker::PhantomData;
 
 struct BenchCircuit<'a, A: Arity<Fr>> {
     n: usize,
-    circuit_type: &'a CircuitType,
+    circuit_type: Option<&'a CircuitType>,
     _a: PhantomData<A>,
 }
 
-impl<A: Arity<Fr>> Circuit<Fr> for BenchCircuit<'_, A> {
-    fn synthesize<CS: ConstraintSystem<Fr>>(self, mut cs: &mut CS) -> Result<(), SynthesisError> {
-        let mut rng = thread_rng();
-        let arity = A::to_usize();
-        let constants = PoseidonConstants::<Fr, A>::new();
-
+impl<A: Arity<Fr>> BenchCircuit<'_, A> {
+    fn synthesize<CS: ConstraintSystem<Fr>>(
+        self,
+        cs: &mut CS,
+        data: Vec<AllocatedNum<Fr>>,
+        constants: &PoseidonConstants<Fr, A>,
+    ) -> Result<(), SynthesisError> {
         for _ in 0..self.n {
-            let mut i = 0;
-            let mut fr_data = vec![Fr::random(&mut rng); arity];
-            let data: Vec<AllocatedNum<Fr>> = (0..arity)
-                .enumerate()
-                .map(|_| {
-                    let fr = Fr::random(&mut rng);
-                    fr_data[i] = fr;
-                    i += 1;
-                    AllocatedNum::alloc(cs.namespace(|| format!("data {}", i)), || Ok(fr)).unwrap()
-                })
-                .collect::<Vec<_>>();
-            let _ = poseidon_hash_circuit(&mut cs, *self.circuit_type, data, &constants)
-                .expect("poseidon hashing failed");
+            let _ = if self.circuit_type.is_some() {
+                poseidon_hash_circuit(cs, *self.circuit_type.unwrap(), data.clone(), constants)
+                    .expect("poseidon hashing failed");
+            } else {
+                poseidon_hash_allocated_mut(cs, data.clone(), constants)
+                    .expect("poseidon hashing failed");
+            };
         }
         Ok(())
+    }
+
+    fn data<CS: ConstraintSystem<Fr>>(cs: &mut CS) -> Vec<AllocatedNum<Fr>> {
+        let mut rng = thread_rng();
+        let arity = A::to_usize();
+
+        let mut fr_data = vec![Fr::random(&mut rng); arity];
+        let data: Vec<AllocatedNum<Fr>> = (0..arity)
+            .map(|i| {
+                let fr = Fr::random(&mut rng);
+                fr_data[i] = fr;
+                AllocatedNum::alloc(cs.namespace(|| format!("data {}", i)), || Ok(fr)).unwrap()
+            })
+            .collect::<Vec<_>>();
+        data
     }
 }
 
@@ -47,6 +59,7 @@ where
     A: Arity<Fr>,
 {
     let mut group = c.benchmark_group(format!("synthesis-{}", A::to_usize()));
+    let constants = PoseidonConstants::<Fr, A>::new();
     for i in 0..4 {
         let num_hashes = 10usize.pow(i);
         for circuit_type in &[CircuitType::Legacy, CircuitType::OptimalAllocated] {
@@ -57,19 +70,39 @@ where
                 ),
                 &num_hashes,
                 |b, n| {
+                    let mut cs = BenchCS::<Fr>::new();
+                    let data = BenchCircuit::<A>::data(&mut cs);
                     b.iter(|| {
-                        let mut cs = BenchCS::<Fr>::new();
                         let circuit = BenchCircuit::<A> {
                             n: *n,
-                            circuit_type,
+                            circuit_type: Some(circuit_type),
                             _a: PhantomData::<A>,
                         };
-                        circuit.synthesize(&mut cs)
+                        circuit.synthesize(&mut cs, data.clone(), &constants)
                     })
                 },
             );
         }
-        // num_hashes *= 10;
+
+        group.bench_with_input(
+            BenchmarkId::new(
+                "hash_allocated_witness",
+                format!("arity: {}, count: {}", A::to_usize(), num_hashes),
+            ),
+            &num_hashes,
+            |b, n| {
+                let mut cs = WitnessCS::<Fr>::new();
+                let data = BenchCircuit::<A>::data(&mut cs);
+                b.iter(|| {
+                    let circuit = BenchCircuit::<A> {
+                        n: *n,
+                        circuit_type: None,
+                        _a: PhantomData::<A>,
+                    };
+                    circuit.synthesize(&mut cs, data.clone(), &constants)
+                })
+            },
+        );
     }
 }
 

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -1,8 +1,8 @@
 use crate::poseidon::{Arity, PoseidonConstants};
-use bellperson::gadgets::num::AllocatedNum;
-use bellperson::util_cs::bench_cs::BenchCS;
-use bellperson::util_cs::witness_cs::WitnessCS;
-use bellperson::{ConstraintSystem, SynthesisError};
+use bellpepper::gadgets::num::AllocatedNum;
+use bellpepper::util_cs::bench_cs::BenchCS;
+use bellpepper::util_cs::witness_cs::WitnessCS;
+use bellpepper::{ConstraintSystem, SynthesisError};
 use blstrs::Scalar as Fr;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use ff::Field;

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bellperson = { workspace = true, default-features = false }
+bellpepper = { workspace = true, default-features = false }
 blake2s_simd = { workspace = true }
 blstrs = { workspace = true, features = ["gpu"] }
 byteorder = { workspace = true }
@@ -23,5 +23,5 @@ structopt = { version = "0.3", default-features = false }
 
 [features]
 default = ["opencl"]
-cuda = ["neptune/cuda", "bellperson/cuda", "ec-gpu-gen/cuda"]
-opencl = ["neptune/opencl", "bellperson/opencl", "ec-gpu-gen/opencl"]
+cuda = ["neptune/cuda", "ec-gpu-gen/cuda"]
+opencl = ["neptune/opencl", "ec-gpu-gen/opencl"]

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -2,6 +2,7 @@
 use std::ops::{AddAssign, MulAssign};
 
 use crate::circuit2::poseidon_hash_allocated;
+use crate::circuit2_witness::poseidon_hash_allocated_witness;
 use crate::hash_type::HashType;
 use crate::matrix::Matrix;
 use crate::mds::SparseMatrix;
@@ -30,7 +31,7 @@ impl CircuitType {
 
 /// Convenience function to potentially ease upgrade transition from legacy to optimal circuits.
 pub fn poseidon_hash_circuit<CS, Scalar, A>(
-    cs: CS,
+    cs: &mut CS,
     circuit_type: CircuitType,
     preimage: Vec<AllocatedNum<Scalar>>,
     constants: &PoseidonConstants<Scalar, A>,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -2,7 +2,6 @@
 use std::ops::{AddAssign, MulAssign};
 
 use crate::circuit2::poseidon_hash_allocated;
-use crate::circuit2_witness::poseidon_hash_allocated_witness;
 use crate::hash_type::HashType;
 use crate::matrix::Matrix;
 use crate::mds::SparseMatrix;
@@ -31,7 +30,7 @@ impl CircuitType {
 
 /// Convenience function to potentially ease upgrade transition from legacy to optimal circuits.
 pub fn poseidon_hash_circuit<CS, Scalar, A>(
-    cs: &mut CS,
+    cs: CS,
     circuit_type: CircuitType,
     preimage: Vec<AllocatedNum<Scalar>>,
     constants: &PoseidonConstants<Scalar, A>,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -6,10 +6,22 @@ use crate::hash_type::HashType;
 use crate::matrix::Matrix;
 use crate::mds::SparseMatrix;
 use crate::poseidon::{Arity, PoseidonConstants};
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::gadgets::num;
-use bellperson::gadgets::num::AllocatedNum;
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
+#[cfg(not(feature = "bellperson"))]
+use bellpepper::{
+    gadgets::{
+        boolean::Boolean,
+        num::{self, AllocatedNum},
+    },
+    ConstraintSystem, LinearCombination, SynthesisError,
+};
+#[cfg(feature = "bellperson")]
+use bellperson::{
+    gadgets::{
+        boolean::Boolean,
+        num::{self, AllocatedNum},
+    },
+    ConstraintSystem, LinearCombination, SynthesisError,
+};
 use ff::{Field, PrimeField};
 use std::marker::PhantomData;
 
@@ -613,8 +625,10 @@ mod tests {
     use super::*;
     use crate::poseidon::HashMode;
     use crate::{Poseidon, Strength};
-    use bellperson::util_cs::test_cs::TestConstraintSystem;
-    use bellperson::ConstraintSystem;
+    #[cfg(not(feature = "bellperson"))]
+    use bellpepper::{util_cs::test_cs::TestConstraintSystem, ConstraintSystem};
+    #[cfg(feature = "bellperson")]
+    use bellperson::{util_cs::test_cs::TestConstraintSystem, ConstraintSystem};
     use blstrs::Scalar as Fr;
     use generic_array::typenum;
     use rand::SeedableRng;

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -6,10 +6,27 @@ use crate::hash_type::HashType;
 use crate::matrix::Matrix;
 use crate::mds::SparseMatrix;
 use crate::poseidon::{Arity, PoseidonConstants};
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::gadgets::num::{self, AllocatedNum};
-use bellperson::gadgets::test::TestConstraintSystem;
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
+
+#[cfg(feature = "bellperson")]
+use bellperson::{
+    gadgets::{
+        boolean::Boolean,
+        num::{self, AllocatedNum},
+        test::TestConstraintSystem,
+    },
+    ConstraintSystem, LinearCombination, SynthesisError,
+};
+
+#[cfg(not(feature = "bellperson"))]
+use bellpepper::{
+    gadgets::{
+        boolean::Boolean,
+        num::{self, AllocatedNum},
+        test::TestConstraintSystem,
+    },
+    ConstraintSystem, LinearCombination, SynthesisError,
+};
+
 use ff::{Field, PrimeField};
 use std::marker::PhantomData;
 
@@ -699,8 +716,10 @@ mod tests {
     use super::*;
     use crate::poseidon::HashMode;
     use crate::{Poseidon, Strength};
-    use bellperson::util_cs::test_cs::TestConstraintSystem;
-    use bellperson::ConstraintSystem;
+    #[cfg(not(feature = "bellperson"))]
+    use bellpepper::{util_cs::test_cs::TestConstraintSystem, ConstraintSystem};
+    #[cfg(feature = "bellperson")]
+    use bellperson::{util_cs::test_cs::TestConstraintSystem, ConstraintSystem};
     use blstrs::Scalar as Fr;
     use generic_array::typenum;
     use rand::SeedableRng;

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -437,21 +437,7 @@ where
 
 /// Create circuit for Poseidon hash, returning an allocated `Num` at the cost of one constraint.
 pub fn poseidon_hash_allocated<CS, Scalar, A>(
-    mut cs: CS,
-    preimage: Vec<AllocatedNum<Scalar>>,
-    constants: &PoseidonConstants<Scalar, A>,
-) -> Result<AllocatedNum<Scalar>, SynthesisError>
-where
-    CS: ConstraintSystem<Scalar>,
-    Scalar: PrimeField,
-    A: Arity<Scalar>,
-{
-    poseidon_hash_allocated_mut(&mut cs, preimage, constants)
-}
-
-/// Create circuit for Poseidon hash, returning an allocated `Num` at the cost of one constraint.
-pub fn poseidon_hash_allocated_mut<CS, Scalar, A>(
-    cs: &mut CS,
+    cs: CS,
     preimage: Vec<AllocatedNum<Scalar>>,
     constants: &PoseidonConstants<Scalar, A>,
 ) -> Result<AllocatedNum<Scalar>, SynthesisError>
@@ -461,7 +447,8 @@ where
     A: Arity<Scalar>,
 {
     if cs.is_witness_generator() {
-        poseidon_hash_allocated_witness(cs, &preimage, constants)
+        let mut cs = cs;
+        poseidon_hash_allocated_witness(&mut cs, &preimage, constants)
     } else {
         let arity = A::to_usize();
         let tag_element = Elt::num_from_fr::<CS>(constants.domain_tag);

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -236,7 +236,7 @@ where
         }
     }
 
-    fn hash_to_allocated<CS: ConstraintSystem<Scalar>>(
+    pub fn hash_to_allocated<CS: ConstraintSystem<Scalar>>(
         &mut self,
         mut cs: CS,
     ) -> Result<AllocatedNum<Scalar>, SynthesisError> {
@@ -429,7 +429,7 @@ where
         self.pos = 1;
     }
 
-    fn debug(&self) {
+    pub(crate) fn debug(&self) {
         let element_frs: Vec<_> = self.elements.iter().map(|n| n.val()).collect::<Vec<_>>();
         dbg!(element_frs, self.constants_offset);
     }

--- a/src/circuit2_witness.rs
+++ b/src/circuit2_witness.rs
@@ -304,10 +304,8 @@ where
                 // mds
                 {
                     for j in 0..width {
-                        // TODO: Optimize this to avoid the Vec.
-                        let column = (0..width).map(|i| m[i][j]).collect::<Vec<_>>();
-
-                        elements_buffer[j] = scalar_product(elements, &column);
+                        elements_buffer[j] =
+                            (0..width).fold(Scalar::ZERO, |acc, i| acc + elements[i] * m[i][j]);
                     }
                     elements.copy_from_slice(&elements_buffer);
                 }

--- a/src/circuit2_witness.rs
+++ b/src/circuit2_witness.rs
@@ -6,12 +6,27 @@ use crate::hash_type::HashType;
 use crate::matrix::Matrix;
 use crate::mds::SparseMatrix;
 use crate::poseidon::{Arity, Poseidon, PoseidonConstants};
-use bellperson::util_cs::witness_cs::SizedWitness;
+#[cfg(not(feature = "bellperson"))]
+use bellpepper::{
+    gadgets::{
+        boolean::Boolean,
+        num::{self, AllocatedNum},
+        test::TestConstraintSystem,
+    },
+    util_cs::witness_cs::SizedWitness,
+    ConstraintSystem, LinearCombination, SynthesisError,
+};
+#[cfg(feature = "bellperson")]
+use bellperson::{
+    gadgets::{
+        boolean::Boolean,
+        num::{self, AllocatedNum},
+        test::TestConstraintSystem,
+    },
+    util_cs::witness_cs::SizedWitness,
+    ConstraintSystem, LinearCombination, SynthesisError,
+};
 
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::gadgets::num::{self, AllocatedNum};
-use bellperson::gadgets::test::TestConstraintSystem;
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::{Field, PrimeField};
 use generic_array::sequence::GenericSequence;
 use generic_array::typenum::Unsigned;
@@ -324,8 +339,16 @@ mod test {
     use crate::circuit2;
     use crate::poseidon::HashMode;
     use crate::{Poseidon, Strength};
-    use bellperson::util_cs::{test_cs::TestConstraintSystem, witness_cs::WitnessCS, Comparable};
-    use bellperson::ConstraintSystem;
+    #[cfg(not(feature = "bellperson"))]
+    use bellpepper::{
+        util_cs::{test_cs::TestConstraintSystem, witness_cs::WitnessCS, Comparable},
+        ConstraintSystem,
+    };
+    #[cfg(feature = "bellperson")]
+    use bellperson::{
+        util_cs::{test_cs::TestConstraintSystem, witness_cs::WitnessCS, Comparable},
+        ConstraintSystem,
+    };
     use blstrs::Scalar as Fr;
     use generic_array::typenum;
     use rand::SeedableRng;

--- a/src/circuit2_witness.rs
+++ b/src/circuit2_witness.rs
@@ -234,7 +234,10 @@ where
 
                 // sparse mds
                 {
-                    elements_buffer[0] = scalar_product(elements, &m.w_hat);
+                    elements_buffer[0] = elements
+                        .iter()
+                        .zip(&m.w_hat)
+                        .fold(Scalar::ZERO, |acc, (&x, &y)| acc + (x * y));
 
                     for j in 1..width {
                         elements_buffer[j] = elements[j] + elements[0] * m.v_rest[j - 1];
@@ -313,12 +316,6 @@ where
 
         elements[1]
     }
-}
-
-fn scalar_product<Scalar: PrimeField>(a: &[Scalar], b: &[Scalar]) -> Scalar {
-    a.iter()
-        .zip(b)
-        .fold(Scalar::ZERO, |acc, (&x, &y)| acc + (x * y))
 }
 
 #[cfg(test)]

--- a/src/circuit2_witness.rs
+++ b/src/circuit2_witness.rs
@@ -104,7 +104,6 @@ where
     fn num_aux(&self) -> usize {
         self.num_constraints()
     }
-
     fn generate_witness_into(&mut self, aux: &mut [Scalar], _inputs: &mut [Scalar]) -> Scalar {
         let width = A::ConstantsSize::to_usize();
         let constants = self.constants;

--- a/src/circuit2_witness.rs
+++ b/src/circuit2_witness.rs
@@ -1,0 +1,484 @@
+/// The `circuit2_witness` module implements witness-generation for the optimal Poseidon hash circuit.
+use std::ops::{AddAssign, MulAssign};
+
+use crate::circuit2::Elt;
+use crate::hash_type::HashType;
+use crate::matrix::Matrix;
+use crate::mds::SparseMatrix;
+use crate::poseidon::{Arity, Poseidon, PoseidonConstants};
+use bellperson::util_cs::witness_cs::SizedWitness;
+
+use bellperson::gadgets::boolean::Boolean;
+use bellperson::gadgets::num::{self, AllocatedNum};
+use bellperson::gadgets::test::TestConstraintSystem;
+use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
+use ff::{Field, PrimeField};
+use generic_array::sequence::GenericSequence;
+use generic_array::typenum::Unsigned;
+use generic_array::GenericArray;
+use std::marker::PhantomData;
+
+/// Create circuit for Poseidon hash, returning an `AllocatedNum` at the cost of one constraint.
+pub fn poseidon_hash_allocated_witness<CS, Scalar, A>(
+    cs: &mut CS,
+    preimage: &[AllocatedNum<Scalar>],
+    constants: &PoseidonConstants<Scalar, A>,
+) -> Result<AllocatedNum<Scalar>, SynthesisError>
+where
+    CS: ConstraintSystem<Scalar>,
+    Scalar: PrimeField,
+    A: Arity<Scalar>,
+{
+    assert!(cs.is_witness_generator());
+    let result = poseidon_hash_witness_into_cs(cs, preimage, constants);
+
+    AllocatedNum::alloc(&mut cs.namespace(|| "result"), || Ok(result))
+}
+
+pub fn poseidon_hash_witness_into_cs<Scalar, A, CS>(
+    cs: &mut CS,
+    preimage: &[AllocatedNum<Scalar>],
+    constants: &PoseidonConstants<Scalar, A>,
+) -> Scalar
+where
+    CS: ConstraintSystem<Scalar>,
+    Scalar: PrimeField,
+    A: Arity<Scalar>,
+{
+    let scalar_preimage = preimage
+        .iter()
+        .map(|elt| elt.get_value().unwrap())
+        .collect::<Vec<_>>();
+    let mut p = Poseidon::new_with_preimage(&scalar_preimage, constants);
+
+    p.generate_witness_into_cs(cs)
+}
+
+pub fn poseidon_hash_witness<Scalar, A>(
+    preimage: &[AllocatedNum<Scalar>],
+    constants: &PoseidonConstants<Scalar, A>,
+) -> (Vec<Scalar>, Scalar)
+where
+    Scalar: PrimeField,
+    A: Arity<Scalar>,
+{
+    let scalar_preimage = preimage
+        .iter()
+        .map(|elt| elt.get_value().unwrap())
+        .collect::<Vec<_>>();
+
+    poseidon_hash_scalar_witness(&scalar_preimage, constants)
+}
+
+pub fn poseidon_hash_scalar_witness<Scalar, A>(
+    preimage: &[Scalar],
+    constants: &PoseidonConstants<Scalar, A>,
+) -> (Vec<Scalar>, Scalar)
+where
+    Scalar: PrimeField,
+    A: Arity<Scalar>,
+{
+    let mut p = Poseidon::new_with_preimage(preimage, constants);
+
+    let (aux, _inputs, result) = p.generate_witness();
+
+    (aux, result)
+}
+
+impl<'a, Scalar, A> SizedWitness<Scalar> for Poseidon<'a, Scalar, A>
+where
+    Scalar: PrimeField,
+    A: Arity<Scalar>,
+{
+    fn num_constraints(&self) -> usize {
+        let s_box_cost = 3;
+        let width = A::ConstantsSize::to_usize();
+        (width * s_box_cost * self.constants.full_rounds)
+            + (s_box_cost * self.constants.partial_rounds)
+    }
+
+    fn num_inputs(&self) -> usize {
+        0
+    }
+
+    fn num_aux(&self) -> usize {
+        self.num_constraints()
+    }
+
+    fn generate_witness_into(&mut self, aux: &mut [Scalar], _inputs: &mut [Scalar]) -> Scalar {
+        let width = A::ConstantsSize::to_usize();
+        let constants = self.constants;
+        let elements = &mut self.elements;
+
+        let mut elements_buffer =
+            GenericArray::<Scalar, A::ConstantsSize>::generate(|_| Scalar::ZERO);
+
+        let c = &constants.compressed_round_constants;
+
+        let mut offset = 0;
+        let mut aux_index = 0;
+        macro_rules! push_aux {
+            ($val:expr) => {
+                aux[aux_index] = $val;
+                aux_index += 1;
+            };
+        }
+
+        assert_eq!(width, elements.len());
+
+        // First Round (Full)
+        {
+            // s-box
+            for elt in elements.iter_mut() {
+                let x = c[offset];
+                let y = c[offset + width];
+                let mut tmp = *elt;
+
+                tmp.add_assign(x);
+                tmp = tmp.square();
+                push_aux!(tmp); // l2
+
+                tmp = tmp.square();
+                push_aux!(tmp); // l4
+
+                tmp = tmp * (*elt + x) + y;
+                push_aux!(tmp); // l5
+
+                *elt = tmp;
+                offset += 1;
+            }
+            offset += width; // post-round keys
+
+            // mds
+            {
+                let m = &constants.mds_matrices.m;
+
+                for j in 0..width {
+                    let scalar_product = m
+                        .iter()
+                        .enumerate()
+                        .fold(Scalar::ZERO, |acc, (n, row)| acc + (row[j] * elements[n]));
+
+                    elements_buffer[j] = scalar_product;
+                }
+                elements.copy_from_slice(&elements_buffer);
+            }
+        }
+
+        // Remaining initial full rounds.
+        {
+            for i in 1..constants.half_full_rounds {
+                // Use pre-sparse matrix on last initial full round.
+                let m = if i == constants.half_full_rounds - 1 {
+                    &constants.pre_sparse_matrix
+                } else {
+                    &constants.mds_matrices.m
+                };
+                {
+                    // s-box
+                    for elt in elements.iter_mut() {
+                        let y = c[offset];
+                        let mut tmp = *elt;
+
+                        tmp = tmp.square();
+                        push_aux!(tmp); // l2
+
+                        tmp = tmp.square();
+                        push_aux!(tmp); // l4
+
+                        tmp = tmp * *elt + y;
+                        push_aux!(tmp); // l5
+
+                        *elt = tmp;
+                        offset += 1;
+                    }
+                }
+
+                // mds
+                {
+                    for j in 0..width {
+                        let scalar_product = m
+                            .iter()
+                            .enumerate()
+                            .fold(Scalar::ZERO, |acc, (n, row)| acc + (row[j] * elements[n]));
+
+                        elements_buffer[j] = scalar_product;
+                    }
+                    elements.copy_from_slice(&elements_buffer);
+                }
+            }
+        }
+
+        // Partial rounds
+        {
+            for i in 0..constants.partial_rounds {
+                // s-box
+
+                // FIXME: a little silly to use a loop here.
+                for elt in elements[0..1].iter_mut() {
+                    let y = c[offset];
+                    let mut tmp = *elt;
+
+                    tmp = tmp.square();
+                    push_aux!(tmp); // l2
+
+                    tmp = tmp.square();
+                    push_aux!(tmp); // l4
+
+                    tmp = tmp * *elt + y;
+                    push_aux!(tmp); // l5
+
+                    *elt = tmp;
+                    offset += 1;
+                }
+                let m = &constants.sparse_matrixes[i];
+
+                // sparse mds
+                {
+                    elements_buffer[0] = scalar_product(elements, &m.w_hat);
+
+                    for j in 1..width {
+                        elements_buffer[j] = elements[j] + elements[0] * m.v_rest[j - 1];
+                    }
+
+                    elements.copy_from_slice(&elements_buffer);
+                }
+            }
+        }
+        // Final full rounds.
+        {
+            let m = &constants.mds_matrices.m;
+            for _ in 1..constants.half_full_rounds {
+                {
+                    // s-box
+                    for elt in elements.iter_mut() {
+                        let y = c[offset];
+                        let mut tmp = *elt;
+
+                        tmp = tmp.square();
+                        push_aux!(tmp); // l2
+
+                        tmp = tmp.square();
+                        push_aux!(tmp); // l4
+
+                        tmp = tmp * *elt + y;
+                        push_aux!(tmp); // l5
+
+                        *elt = tmp;
+                        offset += 1;
+                    }
+                }
+
+                // mds
+                {
+                    for j in 0..width {
+                        let scalar_product = m
+                            .iter()
+                            .enumerate()
+                            .fold(Scalar::ZERO, |acc, (n, row)| acc + (row[j] * elements[n]));
+
+                        elements_buffer[j] = scalar_product;
+                    }
+                    elements.copy_from_slice(&elements_buffer);
+                }
+            }
+
+            // Terminal full round
+            {
+                // s-box
+                for elt in elements.iter_mut() {
+                    let mut tmp = *elt;
+
+                    tmp = tmp.square();
+                    push_aux!(tmp); // l2
+
+                    tmp = tmp.square();
+                    push_aux!(tmp); // l4
+
+                    tmp *= *elt;
+                    push_aux!(tmp); // l5
+
+                    *elt = tmp;
+                }
+
+                // mds
+                {
+                    for j in 0..width {
+                        // TODO: Optimize this to avoid the Vec.
+                        let column = (0..width).map(|i| m[i][j]).collect::<Vec<_>>();
+
+                        elements_buffer[j] = scalar_product(elements, &column);
+                    }
+                    elements.copy_from_slice(&elements_buffer);
+                }
+            }
+        }
+
+        elements[1]
+    }
+}
+
+fn scalar_product<Scalar: PrimeField>(a: &[Scalar], b: &[Scalar]) -> Scalar {
+    a.iter()
+        .zip(b)
+        .fold(Scalar::ZERO, |acc, (&x, &y)| acc + (x * y))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::circuit2;
+    use crate::poseidon::HashMode;
+    use crate::{Poseidon, Strength};
+    use bellperson::util_cs::{test_cs::TestConstraintSystem, witness_cs::WitnessCS, Comparable};
+    use bellperson::ConstraintSystem;
+    use blstrs::Scalar as Fr;
+    use generic_array::typenum;
+    use rand::SeedableRng;
+    use rand_xorshift::XorShiftRng;
+
+    #[test]
+    fn test_poseidon_hash_witness() {
+        test_poseidon_hash_aux::<typenum::U2>(Strength::Standard, 237, false);
+        test_poseidon_hash_aux::<typenum::U4>(Strength::Standard, 288, false);
+        test_poseidon_hash_aux::<typenum::U8>(Strength::Standard, 387, false);
+        test_poseidon_hash_aux::<typenum::U16>(Strength::Standard, 585, false);
+        test_poseidon_hash_aux::<typenum::U24>(Strength::Standard, 777, false);
+        test_poseidon_hash_aux::<typenum::U32>(Strength::Standard, 972, false);
+        test_poseidon_hash_aux::<typenum::U36>(Strength::Standard, 1068, false);
+
+        test_poseidon_hash_aux::<typenum::U2>(Strength::Strengthened, 279, false);
+        test_poseidon_hash_aux::<typenum::U4>(Strength::Strengthened, 330, false);
+        test_poseidon_hash_aux::<typenum::U8>(Strength::Strengthened, 432, false);
+        test_poseidon_hash_aux::<typenum::U16>(Strength::Strengthened, 630, false);
+        test_poseidon_hash_aux::<typenum::U24>(Strength::Strengthened, 822, false);
+        test_poseidon_hash_aux::<typenum::U32>(Strength::Strengthened, 1017, false);
+        test_poseidon_hash_aux::<typenum::U36>(Strength::Strengthened, 1113, false);
+
+        test_poseidon_hash_aux::<typenum::U15>(Strength::Standard, 561, true);
+    }
+
+    // Returns index of first mismatch, along with the mismatched elements if they exist.
+    #[allow(clippy::type_complexity)]
+    fn mismatch<T: PartialEq + Copy>(
+        a: Vec<T>,
+        b: Vec<T>,
+    ) -> Option<(usize, (Option<T>, Option<T>))> {
+        for (i, (x, y)) in a.iter().zip(&b).enumerate() {
+            if x != y {
+                return Some((i, (Some(*x), Some(*y))));
+            }
+        }
+        use std::cmp::Ordering;
+
+        match a.len().cmp(&b.len()) {
+            Ordering::Less => Some((a.len(), (None, Some(b[a.len()])))),
+            Ordering::Greater => Some((b.len(), (Some(a[b.len()]), None))),
+            Ordering::Equal => None,
+        }
+    }
+
+    fn test_poseidon_hash_aux<A>(
+        strength: Strength,
+        expected_constraints: usize,
+        constant_length: bool,
+    ) where
+        A: Arity<Fr>,
+    {
+        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let arity = A::to_usize();
+        let constants_x = if constant_length {
+            PoseidonConstants::<Fr, A>::new_with_strength_and_type(
+                strength,
+                HashType::ConstantLength(arity),
+            )
+        } else {
+            PoseidonConstants::<Fr, A>::new_with_strength(strength)
+        };
+
+        let range = if constant_length {
+            1..=arity
+        } else {
+            arity..=arity
+        };
+        for preimage_length in range {
+            let constants = if constant_length {
+                constants_x.with_length(preimage_length)
+            } else {
+                constants_x.clone()
+            };
+
+            let expected_constraints_calculated = {
+                let width = 1 + arity;
+                let s_box_cost = 3;
+
+                (width * s_box_cost * constants.full_rounds)
+                    + (s_box_cost * constants.partial_rounds)
+            };
+
+            let mut data = |cs: &mut TestConstraintSystem<Fr>, fr_data: &mut [Fr]| {
+                (0..preimage_length)
+                    .map(|i| {
+                        let fr = Fr::random(&mut rng);
+                        fr_data[i] = fr;
+                        AllocatedNum::alloc(cs.namespace(|| format!("data {}", i)), || Ok(fr))
+                            .unwrap()
+                    })
+                    .collect::<Vec<_>>()
+            };
+
+            {
+                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut wcs = WitnessCS::<Fr>::new();
+
+                let mut fr_data = vec![Fr::ZERO; preimage_length];
+                let data: Vec<AllocatedNum<Fr>> = data(&mut cs, &mut fr_data);
+                wcs.extend_aux(&fr_data);
+
+                let _ = circuit2::poseidon_hash_allocated(&mut cs, data.clone(), &constants)
+                    .expect("poseidon hashing failed");
+
+                let out2 = poseidon_hash_allocated_witness(&mut wcs, &data, &constants)
+                    .expect("poseidon hash witness generation failed");
+
+                let cs_inputs = cs.scalar_inputs();
+                let cs_aux = cs.scalar_aux();
+
+                let wcs_inputs = wcs.scalar_inputs();
+                let wcs_aux = wcs.scalar_aux();
+
+                assert_eq!(cs_aux.len(), wcs_aux.len());
+
+                assert_eq!(None, mismatch(cs_inputs, wcs_inputs));
+                dbg!(&cs_aux[220..], &wcs_aux[220..]);
+                assert_eq!(None, mismatch(cs_aux, wcs_aux));
+
+                let mut p = Poseidon::<Fr, A>::new_with_preimage(&fr_data, &constants);
+                let expected: Fr = p.hash_in_mode(HashMode::Correct);
+
+                let expected_constraints_calculated = expected_constraints_calculated + 1;
+                let expected_constraints = expected_constraints + 1;
+
+                assert!(cs.is_satisfied(), "constraints not satisfied");
+
+                assert_eq!(
+                    expected,
+                    out2.get_value().unwrap(),
+                    "witness and non-circuit do not match"
+                );
+
+                assert_eq!(
+                    expected_constraints_calculated,
+                    cs.num_constraints(),
+                    "constraint number miscalculated"
+                );
+
+                assert_eq!(
+                    expected_constraints,
+                    cs.num_constraints(),
+                    "constraint number changed",
+                );
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ compile_error!("The `cuda` and `opencl` features need the `bls` and/or `pasta` f
 /// Poseidon circuit
 pub mod circuit;
 pub mod circuit2;
+pub mod circuit2_witness;
 pub mod error;
 mod matrix;
 mod mds;

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -8,10 +8,25 @@ use crate::sponge::{
     vanilla::{Direction, Mode, SpongeTrait},
 };
 use crate::Strength;
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::gadgets::num::{self, AllocatedNum};
-use bellperson::util_cs::witness_cs::{SizedWitness, WitnessCS};
-use bellperson::{ConstraintSystem, LinearCombination, Namespace, SynthesisError};
+#[cfg(not(feature = "bellperson"))]
+use bellpepper::{
+    gadgets::{
+        boolean::Boolean,
+        num::{self, AllocatedNum},
+    },
+    util_cs::witness_cs::{SizedWitness, WitnessCS},
+    ConstraintSystem, LinearCombination, Namespace, SynthesisError,
+};
+#[cfg(feature = "bellperson")]
+use bellperson::{
+    gadgets::{
+        boolean::Boolean,
+        num::{self, AllocatedNum},
+    },
+    util_cs::witness_cs::{SizedWitness, WitnessCS},
+    ConstraintSystem, LinearCombination, Namespace, SynthesisError,
+};
+
 use ff::{Field, PrimeField};
 use std::collections::VecDeque;
 use std::marker::PhantomData;
@@ -254,6 +269,12 @@ mod tests {
     use super::*;
     use crate::sponge::vanilla::Sponge;
 
+    #[cfg(not(feature = "bellperson"))]
+    use bellpepper::{
+        util_cs::{test_cs::TestConstraintSystem, witness_cs::WitnessCS},
+        Circuit,
+    };
+    #[cfg(feature = "bellperson")]
     use bellperson::{
         util_cs::{test_cs::TestConstraintSystem, witness_cs::WitnessCS},
         Circuit,

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -10,6 +10,7 @@ use crate::sponge::{
 use crate::Strength;
 use bellperson::gadgets::boolean::Boolean;
 use bellperson::gadgets::num::{self, AllocatedNum};
+use bellperson::util_cs::witness_cs::{SizedWitness, WitnessCS};
 use bellperson::{ConstraintSystem, LinearCombination, Namespace, SynthesisError};
 use ff::{Field, PrimeField};
 use std::collections::VecDeque;
@@ -32,6 +33,7 @@ where
     queue: VecDeque<Elt<F>>,
     pattern: IOPattern,
     io_count: usize,
+    poseidon: Poseidon<'a, F, A>,
     _c: PhantomData<C>,
 }
 
@@ -54,6 +56,7 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> SpongeTrait<'
             state: PoseidonCircuit2::new_empty::<CS>(constants),
             queue: VecDeque::with_capacity(A::to_usize()),
             pattern: IOPattern(Vec::new()),
+            poseidon: Poseidon::new(constants),
             io_count: 0,
             _c: Default::default(),
         }
@@ -98,6 +101,7 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> SpongeTrait<'
     }
 
     fn set_element(&mut self, index: usize, elt: Self::Elt) {
+        self.poseidon.elements[index] = elt.val().unwrap();
         self.state.elements[index] = elt;
     }
 
@@ -128,8 +132,22 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> SpongeTrait<'
 
     fn permute_state(&mut self, ns: &mut Self::Acc) -> Result<(), Self::Error> {
         self.permutation_count += 1;
-        self.state
-            .hash(&mut ns.namespace(|| format!("permutation {}", self.permutation_count)))?;
+
+        if ns.is_witness_generator() {
+            self.poseidon.generate_witness_into_cs(ns);
+
+            for (elt, scalar) in self
+                .state
+                .elements
+                .iter_mut()
+                .zip(self.poseidon.elements.iter())
+            {
+                *elt = Elt::num_from_fr::<CS>(*scalar);
+            }
+        } else {
+            self.state
+                .hash(&mut ns.namespace(|| format!("permutation {}", self.permutation_count)))?;
+        };
 
         Ok(())
     }
@@ -236,7 +254,10 @@ mod tests {
     use super::*;
     use crate::sponge::vanilla::Sponge;
 
-    use bellperson::{util_cs::test_cs::TestConstraintSystem, Circuit};
+    use bellperson::{
+        util_cs::{test_cs::TestConstraintSystem, witness_cs::WitnessCS},
+        Circuit,
+    };
     use blstrs::Scalar as Fr;
     use generic_array::typenum;
     use rand::{Rng, SeedableRng};
@@ -428,20 +449,39 @@ mod tests {
             SpongeOp::Squeeze(3),
         ]);
 
+        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut wcs = WitnessCS::<Fr>::new();
         let circuit_output = {
             let p = Sponge::<Fr, typenum::U5>::api_constants(Strength::Standard);
+
             let mut sponge = SpongeCircuit::new_with_constants(&p, Mode::Simplex);
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut wsponge = SpongeCircuit::new_with_constants(&p, Mode::Simplex);
+
             let mut ns = cs.namespace(|| "ns");
             let acc = &mut ns;
 
+            let mut wns = wcs.namespace(|| "ns");
+            let wacc = &mut wns;
+
             sponge.start(parameter.clone(), None, acc);
+            wsponge.start(parameter.clone(), None, wacc);
+            sponge.state.debug();
+            wsponge.state.debug();
             SpongeAPI::absorb(
                 &mut sponge,
                 1,
                 &[Elt::num_from_fr::<TestConstraintSystem<Fr>>(Fr::from(123))],
                 acc,
             );
+            SpongeAPI::absorb(
+                &mut wsponge,
+                1,
+                &[Elt::num_from_fr::<WitnessCS<Fr>>(Fr::from(123))],
+                wacc,
+            );
+            sponge.state.debug();
+            wsponge.state.debug();
+
             SpongeAPI::absorb(
                 &mut sponge,
                 5,
@@ -454,13 +494,45 @@ mod tests {
                 ],
                 acc,
             );
+            SpongeAPI::absorb(
+                &mut wsponge,
+                5,
+                &[
+                    Elt::num_from_fr::<WitnessCS<Fr>>(Fr::from(123)),
+                    Elt::num_from_fr::<WitnessCS<Fr>>(Fr::from(123)),
+                    Elt::num_from_fr::<WitnessCS<Fr>>(Fr::from(123)),
+                    Elt::num_from_fr::<WitnessCS<Fr>>(Fr::from(123)),
+                    Elt::num_from_fr::<WitnessCS<Fr>>(Fr::from(123)),
+                ],
+                wacc,
+            );
+            sponge.state.debug();
+            wsponge.state.debug();
 
+            dbg!("last squeeze");
             let output = SpongeAPI::squeeze(&mut sponge, 3, acc);
+            let woutput = SpongeAPI::squeeze(&mut wsponge, 3, wacc);
+
+            sponge.state.debug();
+            wsponge.state.debug();
 
             sponge.finish(acc).unwrap();
+            wsponge.finish(wacc).unwrap();
+
+            let output_scalars = output.iter().map(|x| x.val()).collect::<Vec<_>>();
+            let woutput_scalars = woutput.iter().map(|x| x.val()).collect::<Vec<_>>();
+            assert_eq!(output_scalars, woutput_scalars);
 
             output
         };
+        let cs_aux = cs.scalar_aux();
+        let wcs_aux = wcs.scalar_aux();
+        let a = &cs_aux[300..320];
+        let b = &wcs_aux[300..320];
+        dbg!(cs_aux.len(), wcs_aux.len(), a, b);
+
+        assert_eq!(None, mismatch(cs_aux, wcs_aux));
+        assert!(cs.is_satisfied());
 
         let non_circuit_output = {
             let p = Sponge::<Fr, typenum::U5>::api_constants(Strength::Standard);
@@ -657,15 +729,39 @@ mod tests {
 
     fn test_sponge_synthesis_aux<F: PrimeField, A: Arity<F>>() {
         let p: PoseidonConstants<F, A> = Sponge::api_constants(Strength::Standard);
-        let s = S { p };
+        let s = S { p: p.clone() };
+        let s2 = S { p };
 
         let mut cs = TestConstraintSystem::<F>::new();
+        let mut wcs = WitnessCS::<F>::new();
+
         s.synthesize(&mut cs).unwrap();
+        s2.synthesize(&mut wcs).unwrap();
     }
 
     #[test]
     fn test_sponge_synthesis() {
         test_sponge_synthesis_aux::<Fr, typenum::U2>();
         test_sponge_synthesis_aux::<Fr, typenum::U4>();
+    }
+
+    // Returns index of first mismatch, along with the mismatched elements if they exist.
+    #[allow(clippy::type_complexity)]
+    fn mismatch<T: PartialEq + Copy>(
+        a: Vec<T>,
+        b: Vec<T>,
+    ) -> Option<(usize, (Option<T>, Option<T>))> {
+        for (i, (x, y)) in a.iter().zip(&b).enumerate() {
+            if x != y {
+                return Some((i, (Some(*x), Some(*y))));
+            }
+        }
+        use std::cmp::Ordering;
+
+        match a.len().cmp(&b.len()) {
+            Ordering::Less => Some((a.len(), (None, Some(b[a.len()])))),
+            Ordering::Greater => Some((b.len(), (Some(a[b.len()]), None))),
+            Ordering::Equal => None,
+        }
     }
 }


### PR DESCRIPTION
# [Do not merge until updated for bellpepper.]

**UPDATE**: This PR now uses [bellpepper](https://github.com/lurk-lab/bellpepper). However, we intend to retain bellperson compatibilty for those requiring it. This PR switches to bellpepper to expedite upstream changes. Therefore it should also add a mechanism for using bellperson instead, when needed.

**UPDATE2**: I have added a `bellperson` feature, so now this only needs to be updated to exercise the feature flag on CI.

**UPDATE3**: Actually, the new work still depends on `bellperson` git dependency, so maybe the answer is to make the new work unsupported when `bellperson` feature is selected.

This PR makes use of https://github.com/filecoin-project/bellperson/pull/309 to implement `SizedWitness` for `poseidon`. The resulting witness is for the `circuit2` variant, with final result allocated. Several entry points are provided, to support usages where the witness should be, for example, generated directly into the constraint system, or returned for later use.

The synthesis benchmark is extended to allow comparison with previous synthesis (using `BenchCS`, which carries minimal overhead). Note that the `hash_allocated_witness` runs are about 16x faster than the `Optimal Allocated Poseidon Circuit` runs.

```
➜  neptune git:(witness-gen) ✗ cargo criterion --bench synthesis
   Compiling neptune v9.0.0 (/Users/clwk/fil/neptune)
    Finished bench [optimized] target(s) in 5.82s
synthesis-8/Legacy Poseidon Circuit/arity: 8, count: 1                                                                            
                        time:   [606.56 µs 608.75 µs 612.32 µs]
                        change: [-0.6349% -0.2242% +0.2068%] (p = 0.37 > 0.05)
                        No change in performance detected.
synthesis-8/Optimal Allocated Poseidon Circuit,/arity: 8, count: 1                                                                            
                        time:   [591.16 µs 591.63 µs 592.15 µs]
                        change: [-1.3293% -0.5826% -0.1104%] (p = 0.08 > 0.05)
                        No change in performance detected.
synthesis-8/hash_allocated_witness/arity: 8, count: 1                                                                            
                        time:   [36.666 µs 36.695 µs 36.747 µs]
                        change: [+0.6121% +0.8506% +1.1294%] (p = 0.00 < 0.05)
                        Change within noise threshold.
synthesis-8/Legacy Poseidon Circuit/arity: 8, count: 10                                                                           
                        time:   [6.1382 ms 6.1424 ms 6.1468 ms]
                        change: [-1.9551% -1.0453% -0.2484%] (p = 0.02 < 0.05)
                        Change within noise threshold.
synthesis-8/Optimal Allocated Poseidon Circuit,/arity: 8, count: 10                                                                           
                        time:   [5.9172 ms 5.9187 ms 5.9217 ms]
                        change: [+0.8503% +1.1880% +1.5227%] (p = 0.00 < 0.05)
                        Change within noise threshold.
synthesis-8/hash_allocated_witness/arity: 8, count: 10                                                                           
                        time:   [365.80 µs 366.54 µs 367.76 µs]
                        change: [-15.570% -14.962% -14.400%] (p = 0.00 < 0.05)
                        Performance has improved.
synthesis-8/Legacy Poseidon Circuit/arity: 8, count: 100                                                                           
                        time:   [61.153 ms 61.457 ms 61.860 ms]
                        change: [+2.2618% +2.5457% +2.9353%] (p = 0.00 < 0.05)
                        Performance has regressed.
synthesis-8/Optimal Allocated Poseidon Circuit,/arity: 8, count: 100                                                                           
                        time:   [58.389 ms 58.418 ms 58.446 ms]
                        change: [-32.491% -32.425% -32.362%] (p = 0.00 < 0.05)
                        Performance has improved.
synthesis-8/hash_allocated_witness/arity: 8, count: 100                                                                            
                        time:   [3.6248 ms 3.6411 ms 3.6632 ms]
                        change: [-95.978% -95.962% -95.943%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking synthesis-8/Legacy Poseidon Circuit/arity: 8, count: 1000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.1s.
synthesis-8/Legacy Poseidon Circuit/arity: 8, count: 1000                                                                          
                        time:   [605.64 ms 607.31 ms 609.05 ms]
                        change: [+1.1024% +1.3995% +1.7238%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking synthesis-8/Optimal Allocated Poseidon Circuit,/arity: 8, count: 1000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.9s.
synthesis-8/Optimal Allocated Poseidon Circuit,/arity: 8, count: 1000                                                                          
                        time:   [585.13 ms 587.99 ms 591.48 ms]
                        change: [-32.349% -31.993% -31.619%] (p = 0.00 < 0.05)
                        Performance has improved.
synthesis-8/hash_allocated_witness/arity: 8, count: 1000                                                                           
                        time:   [36.332 ms 36.387 ms 36.419 ms]
                        change: [-95.984% -95.973% -95.962%] (p = 0.00 < 0.05)
                        Performance has improved.
```