### PR TITLE
[Do not merge until Git dependencies removed] Uncompressed Encodings for Affine Points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,6 @@ pasta = ["pasta_curves/gpu"]
 members = [
   "gbench",
 ]
+
+[patch.crates-io]
+pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves.git", branch = "uncompressed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ ff = "0.13.0"
 generic-array = "0.14.6"
 itertools = { version = "0.8.2" }
 log = "0.4.17"
-pasta_curves = { version = "0.5", features = ["serde"] }
+# pasta_curves = { version = "0.5", features = ["serde"] }
+pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves.git", branch = "uncompressed", features = ["serde"] }
 trait-set = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 
@@ -37,7 +38,8 @@ sha2 = "0.9"
 blstrs = "0.7.0"
 ec-gpu = { version = "0.2.0", optional = true }
 ec-gpu-gen = { version = "0.6.0", optional = true }
-pasta_curves = { version = "0.5", features = ["serde"] }
+# pasta_curves = { version = "0.5", features = ["serde"] }
+pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves.git", branch = "uncompressed", features = ["serde"] }
 
 [[bench]]
 name = "hash"
@@ -73,6 +75,3 @@ pasta = ["pasta_curves/gpu"]
 members = [
   "gbench",
 ]
-
-[patch.crates-io]
-pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves.git", branch = "uncompressed" }


### PR DESCRIPTION
This PR patches the `pasta_curve` dependency to the latest on https://github.com/lurk-lab/pasta_curves/pull/2 to allow development/internal use of the `UncompressedEncoding` API until https://github.com/zcash/pasta_curves/pull/73 is merged.