### PR TITLE
Unsafe Serialization for Poseidon Constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ log = "0.4.17"
 pasta_curves = { git="https://github.com/lurk-lab/pasta_curves", branch="dev", features = ["serde"] }
 trait-set = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
+abomonation = "0.7.3"
+abomonation_derive = { git = "https://github.com/winston-h-zhang/abomonation_derive.git" }
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/examples/poseidon_constants_serde.rs
+++ b/examples/poseidon_constants_serde.rs
@@ -1,0 +1,22 @@
+use abomonation::{decode, encode};
+use blstrs::Scalar as Fr;
+use generic_array::typenum::U24;
+use neptune::{poseidon::PoseidonConstants, Strength};
+
+fn main() {
+    let mut bytes = Vec::new();
+    unsafe {
+        let constants = PoseidonConstants::<Fr, U24>::new_with_strength(Strength::Standard);
+        encode(&constants, &mut bytes).unwrap()
+    };
+    println!("Encoded!");
+    println!("Read size: {}", bytes.len());
+
+    if let Some((result, remaining)) = unsafe { decode::<PoseidonConstants<Fr, U24>>(&mut bytes) } {
+        let constants = PoseidonConstants::<Fr, U24>::new_with_strength(Strength::Standard);
+        assert!(result.clone() == constants.clone(), "not equal!");
+        assert!(remaining.len() == 0);
+    } else {
+        println!("Something terrible happened");
+    }
+}

--- a/examples/poseidon_constants_serde.rs
+++ b/examples/poseidon_constants_serde.rs
@@ -14,8 +14,8 @@ fn main() {
 
     if let Some((result, remaining)) = unsafe { decode::<PoseidonConstants<Fr, U24>>(&mut bytes) } {
         let constants = PoseidonConstants::<Fr, U24>::new_with_strength(Strength::Standard);
-        assert!(result.clone() == constants.clone(), "not equal!");
-        assert!(remaining.len() == 0);
+        assert!(result.clone() == constants, "not equal!");
+        assert!(remaining.is_empty());
     } else {
         println!("Something terrible happened");
     }

--- a/src/hash_type.rs
+++ b/src/hash_type.rs
@@ -11,14 +11,17 @@
 /// `Strength` with `HashType` so that hashes with `Strength` other than `Standard` (currently only `Strengthened`)
 /// may still express the full range of hash function types.
 use crate::{Arity, Strength};
+use abomonation::Abomonation;
+use abomonation_derive::Abomonation;
 use ff::PrimeField;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Abomonation)]
 #[serde(bound(
     serialize = "F: PrimeField + Serialize, A: Arity<F>",
     deserialize = "F: PrimeField + Deserialize<'de>, A: Arity<F>"
 ))]
+#[abomonation_omit_bounds]
 pub enum HashType<F: PrimeField, A: Arity<F>> {
     MerkleTree,
     MerkleTreeSparse(u64),
@@ -71,7 +74,8 @@ impl<F: PrimeField, A: Arity<F>> HashType<F, A> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Abomonation)]
+#[abomonation_omit_bounds]
 pub enum CType<F: PrimeField, A: Arity<F>> {
     Arbitrary(u64),
     // See: https://github.com/bincode-org/bincode/issues/424
@@ -79,6 +83,7 @@ pub enum CType<F: PrimeField, A: Arity<F>> {
     // the generated code ends up being correct. But, in the future, do not
     // carelessly add new variants to this enum.
     #[serde(skip)]
+    #[abomonation_skip]
     _Phantom((F, A)),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub use crate::poseidon::{Arity, Poseidon};
 use crate::round_constants::generate_constants;
 use crate::round_numbers::{round_numbers_base, round_numbers_strengthened};
+use abomonation_derive::Abomonation;
 #[cfg(test)]
 use blstrs::Scalar as Fr;
 pub use error::Error;
@@ -97,7 +98,7 @@ pub(crate) const TEST_SEED: [u8; 16] = [
     0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc, 0xe5,
 ];
 
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Abomonation)]
 pub enum Strength {
     Standard,
     Strengthened,

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -1,6 +1,8 @@
 // Allow `&Matrix` in function signatures.
 #![allow(clippy::ptr_arg)]
 
+use abomonation::Abomonation;
+use abomonation_derive::Abomonation;
 use ff::PrimeField;
 use serde::{Deserialize, Serialize};
 
@@ -9,13 +11,20 @@ use crate::matrix::{
     apply_matrix, invert, is_identity, is_invertible, is_square, mat_mul, minor, transpose, Matrix,
 };
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Abomonation)]
+#[abomonation_bounds(where F::Repr: Abomonation)]
 pub struct MdsMatrices<F: PrimeField> {
+    #[abomonate_with(Vec<Vec<F::Repr>>)]
     pub m: Matrix<F>,
+    #[abomonate_with(Vec<Vec<F::Repr>>)]
     pub m_inv: Matrix<F>,
+    #[abomonate_with(Vec<Vec<F::Repr>>)]
     pub m_hat: Matrix<F>,
+    #[abomonate_with(Vec<Vec<F::Repr>>)]
     pub m_hat_inv: Matrix<F>,
+    #[abomonate_with(Vec<Vec<F::Repr>>)]
     pub m_prime: Matrix<F>,
+    #[abomonate_with(Vec<Vec<F::Repr>>)]
     pub m_double_prime: Matrix<F>,
 }
 
@@ -45,11 +54,14 @@ pub fn derive_mds_matrices<F: PrimeField>(m: Matrix<F>) -> MdsMatrices<F> {
 /// This means its first row and column are each dense, and the interior matrix
 /// (minor to the element in both the row and column) is the identity.
 /// We will pluralize this compact structure `sparse_matrixes` to distinguish from `sparse_matrices` from which they are created.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Abomonation)]
+#[abomonation_bounds(where F::Repr: Abomonation)]
 pub struct SparseMatrix<F: PrimeField> {
     /// `w_hat` is the first column of the M'' matrix. It will be directly multiplied (scalar product) with a row of state elements.
+    #[abomonate_with(Vec<F::Repr>)]
     pub w_hat: Vec<F>,
     /// `v_rest` contains all but the first (already included in `w_hat`).
+    #[abomonate_with(Vec<F::Repr>)]
     pub v_rest: Vec<F>,
 }
 

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -1291,7 +1291,7 @@ mod tests {
             unsafe { decode::<PoseidonConstants<Fr, U2>>(&mut bytes) }
         {
             assert!(result == &constants);
-            assert!(remaining.len() == 0);
+            assert!(remaining.is_empty());
         }
     }
 }

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -5,6 +5,8 @@ use crate::poseidon_alt::{hash_correct, hash_optimized_dynamic};
 use crate::preprocessing::compress_round_constants;
 use crate::{matrix, quintic_s_box, BatchHasher, Strength, DEFAULT_STRENGTH};
 use crate::{round_constants, round_numbers, Error};
+use abomonation::Abomonation;
+use abomonation_derive::Abomonation;
 use ff::PrimeField;
 use generic_array::{sequence::GenericSequence, typenum, ArrayLength, GenericArray};
 use serde::{Deserialize, Serialize};
@@ -78,20 +80,22 @@ where
 /// and [`Arity`] as [`Poseidon`] instance that consumes it.
 ///
 /// See original [Poseidon paper](https://eprint.iacr.org/2019/458.pdf) for more details.
-#[derive(Debug, Clone, PartialEq)]
-pub struct PoseidonConstants<F, A>
-where
-    F: PrimeField,
-    A: Arity<F>,
+#[derive(Debug, Clone, PartialEq, Abomonation)]
+#[abomonation_bounds(where F::Repr: Abomonation)]
+pub struct PoseidonConstants<F: PrimeField, A: Arity<F>>
 {
     pub mds_matrices: MdsMatrices<F>,
-    pub round_constants: Option<Vec<F>>,
+    #[abomonate_with(Option<Vec<F::Repr>>)]
+    pub round_constants: Option<Vec<F>>, // TODO: figure out how to automatically allocate `None`
+    #[abomonate_with(Vec<F::Repr>)]
     pub compressed_round_constants: Vec<F>,
+    #[abomonate_with(Matrix<F::Repr>)]
     pub pre_sparse_matrix: Matrix<F>,
     pub sparse_matrixes: Vec<SparseMatrix<F>>,
     pub strength: Strength,
     /// The domain tag is the first element of a Poseidon permutation.
     /// This extra element is necessary for 128-bit security.
+    #[abomonate_with(F::Repr)]
     pub domain_tag: F,
     pub full_rounds: usize,
     pub half_full_rounds: usize,
@@ -917,6 +921,7 @@ mod tests {
     use super::*;
     use crate::sponge::vanilla::SpongeTrait;
     use crate::*;
+    use abomonation::{decode, encode};
     use blstrs::Scalar as Fr;
     use ff::Field;
     use generic_array::typenum;
@@ -1274,5 +1279,20 @@ mod tests {
             standard_constants.partial_rounds,
             default_constants.partial_rounds
         );
+    }
+    
+    #[test]
+    fn roundtrip_abomonation() {
+        let mut constants = PoseidonConstants::<Fr, U2>::new();
+        constants.round_constants = None;
+        let mut bytes = Vec::new();
+        unsafe { encode(&constants, &mut bytes).unwrap() };
+
+        if let Some((result, remaining)) =
+            unsafe { decode::<PoseidonConstants<Fr, U2>>(&mut bytes) }
+        {
+            assert!(result == &constants);
+            assert!(remaining.len() == 0);
+        }
     }
 }

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -82,8 +82,7 @@ where
 /// See original [Poseidon paper](https://eprint.iacr.org/2019/458.pdf) for more details.
 #[derive(Debug, Clone, PartialEq, Abomonation)]
 #[abomonation_bounds(where F::Repr: Abomonation)]
-pub struct PoseidonConstants<F: PrimeField, A: Arity<F>>
-{
+pub struct PoseidonConstants<F: PrimeField, A: Arity<F>> {
     pub mds_matrices: MdsMatrices<F>,
     #[abomonate_with(Option<Vec<F::Repr>>)]
     pub round_constants: Option<Vec<F>>, // TODO: figure out how to automatically allocate `None`
@@ -1280,7 +1279,7 @@ mod tests {
             default_constants.partial_rounds
         );
     }
-    
+
     #[test]
     fn roundtrip_abomonation() {
         let mut constants = PoseidonConstants::<Fr, U2>::new();


### PR DESCRIPTION
This PR implements the `Abomonation` traits necessary for the upstream of faster public parameter caching in Nova. See https://github.com/lurk-lab/lurk-rs/pull/399 for details.

(This is also a copy-paste of https://github.com/winston-h-zhang/neptune/pull/1, moving the work there to a `lurk-lab` fork.)