### PR TITLE
refactor: Bump rust-version to 1.64 and use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,23 +6,22 @@ authors = ["porcuquine <porcuquine@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lurk-lab/neptune"
-resolver = "2"
-rust-version = "1.62.1"
+rust-version = "1.64.0"
 
 [dependencies]
-bellperson = { version = "0.25", default-features = false }
-blake2s_simd = "0.5"
-blstrs = { version = "0.7.0", optional = true }
-byteorder = "1"
-ec-gpu = { version = "0.2.0", optional = true }
-ec-gpu-gen = { version = "0.6.0", optional = true }
-ff = "0.13.0"
-generic-array = "0.14.6"
+bellperson = { workspace = true }
+blake2s_simd = { workspace = true }
+blstrs = { workspace = true, optional = true }
+byteorder = { workspace = true }
+ec-gpu = { workspace = true, optional = true }
+ec-gpu-gen = { workspace = true, optional = true }
+ff ={ workspace = true }
+generic-array = { workspace = true }
 itertools = { version = "0.8.2" }
-log = "0.4.17"
-pasta_curves = { version = "0.5", features = ["serde"] }
-trait-set = "0.3.0"
+log = { workspace = true }
+pasta_curves = { workspace = true, features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
+trait-set = "0.3.0"
 
 [dev-dependencies]
 bincode = "1.3.3"
@@ -34,10 +33,10 @@ serde_json = "1.0.94"
 sha2 = "0.9"
 
 [build-dependencies]
-blstrs = "0.7.0"
-ec-gpu = { version = "0.2.0", optional = true }
-ec-gpu-gen = { version = "0.6.0", optional = true }
-pasta_curves = { version = "0.5", features = ["serde"] }
+blstrs = { workspace = true }
+ec-gpu = { workspace = true, optional = true }
+ec-gpu-gen = { workspace = true, optional = true }
+pasta_curves = { workspace = true, features = ["serde"] }
 
 [[bench]]
 name = "hash"
@@ -70,6 +69,20 @@ bls = ["blstrs/gpu"]
 pasta = ["pasta_curves/gpu"]
 
 [workspace]
+resolver = "2"
 members = [
   "gbench",
 ]
+
+# Dependencies that should be kept in sync through the whole workspace
+[workspace.dependencies]
+bellperson = { version = "0.25", default-features = false }
+blake2s_simd = "0.5"
+blstrs = { version = "0.7.0" }
+ff = "0.13.0"
+generic-array = "0.14.6"
+pasta_curves = { version = "0.5" }
+ec-gpu = { version = "0.2.0" }
+ec-gpu-gen = { version = "0.6.0" }
+log = "0.4.17"
+byteorder = "1"

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -7,19 +7,19 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bellperson = { version = "0.25.0", default-features = false }
-blake2s_simd = "0.5"
-byteorder = "1"
+bellperson = { workspace = true, default-features = false }
+blake2s_simd = { workspace = true }
+blstrs = { workspace = true, features = ["gpu"] }
+byteorder = { workspace = true }
+ec-gpu = { workspace = true }
+ec-gpu-gen = { workspace = true }
 env_logger = "0.7.1"
-ff = "0.13.0"
-generic-array = "0.14.6"
-log = "0.4.17"
+ff = { workspace = true }
+generic-array = { workspace = true }
+log = { workspace = true }
 neptune = { path = "../", default-features = false, features = ["arity8", "arity11", "bls", "pasta"] }
+pasta_curves = { workspace = true, features = ["gpu"] }
 structopt = { version = "0.3", default-features = false }
-blstrs = { version = "0.7.0", features = ["gpu"] }
-pasta_curves = { version = "0.5.1", features = ["gpu"]}
-ec-gpu = "0.2.0"
-ec-gpu-gen = "0.6.0"
 
 [features]
 default = ["opencl"]


### PR DESCRIPTION
See https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table