### PR TITLE
ci: setup Dependabot ci udpates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+  - package-ecosystem: cargo
+    directory: /
+    pull-request-branch-name:
+      separator: "-"
+    schedule:
+      interval: weekly
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/upstream_update.yml
+++ b/.github/workflows/upstream_update.yml
@@ -46,7 +46,7 @@ jobs:
       if: steps.rebase.outcome == 'success'
     - name: Run a trivial test
       id: test
-      run: cargo check --all --tests --benches
+      run: cargo check --tests --benches
       if: steps.rebase.outcome == 'success'
       continue-on-error: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ blstrs = { workspace = true }
 criterion = "0.4.0"
 rand = "0.8.5"
 rand_xorshift = "0.3.0"
-serde_json = "1.0.94"
+serde_json = "1.0.103"
 sha2 = "0.9"
 
 [build-dependencies]
@@ -80,9 +80,9 @@ bellperson = { version = "0.25", default-features = false }
 blake2s_simd = "0.5"
 blstrs = { version = "0.7.0" }
 ff = "0.13.0"
-generic-array = "0.14.6"
+generic-array = "0.14.7"
 pasta_curves = { version = "0.5" }
 ec-gpu = { version = "0.2.0" }
 ec-gpu-gen = { version = "0.6.0" }
-log = "0.4.17"
+log = "0.4.19"
 byteorder = "1"


### PR DESCRIPTION
- adds a dependabot config for weekly updates, which uses the [group](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/) option to avoid numerous PRs,
- allow the auto-rebase of dev on main w/o running checks for gbench (which requires PGU),
- performs one round of cargo upgrade to minimize noise