### PR TITLE
Switch to bellpepper

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,5 @@
+too-many-arguments-threshold = 20
+disallowed-methods = [
+    # we use a re-export to import bellperson
+    { path = "bellperson", reason = "use our custom inditection bellbar instead" },
+]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+        arith: ["", "bellperson"]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings
@@ -51,15 +52,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       # make sure benches don't bit-rot
       - name: build benches
-        # TODO: --all-features
         run: cargo build --benches --release
       - name: cargo test
-        # TODO: --all-features
         run: |
-          cargo nextest run --release
+          cargo nextest run --release --features ${{ matrix.arith }}
+        if: ${{ matrix.arith != '' }}
+      - run: cargo nextest run --release
+        if: ${{ matrix.arith == '' }}
       - name: Doctests
         run: |
-          cargo test --doc
+          cargo test --doc --features ${{ matrix.arith }}
+        if: ${{ matrix.arith != '' }}
+      - run: cargo test --doc
+        if: ${{ matrix.arith == '' }}
 
   clippy:
     runs-on: ubuntu-latest
@@ -87,6 +92,7 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - uses: Swatinem/rust-cache@v2
     - name: Install cargo-msrv
       run: cargo install cargo-msrv
     - name: Check Rust MSRV
@@ -96,6 +102,9 @@ jobs:
   test-cuda:
     name: Rust tests on CUDA
     runs-on: self-hosted
+    strategy:
+      matrix:
+        arith: ["", "bellperson"]
     env:
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITITES: compute,utility
@@ -120,7 +129,7 @@ jobs:
       - run: nvcc --version
       - name: CUDA tests
         run: |
-          cargo nextest run --release --no-default-features --features cuda,pasta,bls,arity2,arity4,arity8,arity11,arity16,arity24,arity36
+          cargo nextest run --release --no-default-features --features cuda,pasta,bls,arity2,arity4,arity8,arity11,arity16,arity24,arity36,${{matrix.arith}}
 
     # Runs the test suite on a self-hosted GPU machine with CUDA and OpenCL enabled (that is using the OpenCL backend for NVIDIA GPUs)
   test-opencl:
@@ -156,5 +165,4 @@ jobs:
       - run: clinfo
       - name: OpenCL tests
         run: |
-          cargo nextest run --release --all-features
-      
+          cargo nextest run --release --no-default-features --features cuda,opencl,pasta,bls,arity2,arity4,arity8,arity11,arity16,arity24,arity36,${{matrix.arith}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/lurk-lab/neptune"
 rust-version = "1.64.0"
 
 [dependencies]
-bellperson = { workspace = true }
+bellpepper = { workspace = true }
+bellperson = { workspace = true, optional = true }
 blake2s_simd = { workspace = true }
 blstrs = { workspace = true, optional = true }
 byteorder = { workspace = true }
@@ -51,8 +52,9 @@ incremental = false
 codegen-units = 1
 
 [features]
-default = ["bellperson/default"]
+default = []
 cuda = ["ec-gpu-gen/cuda", "ec-gpu", "pasta_curves/gpu"]
+bellperson = ["bellperson/default"]
 opencl = ["ec-gpu-gen/opencl", "ec-gpu", "pasta_curves/gpu"]
 # The supported arities for Poseidon running on the GPU are specified at compile-time.
 arity2 = []
@@ -77,6 +79,7 @@ members = [
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 bellperson = { version = "0.25", default-features = false }
+bellpepper = { version = "0.1.2", default-features = false }
 blake2s_simd = "0.5"
 blstrs = { version = "0.7.0" }
 ff = "0.13.0"

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -1,7 +1,7 @@
+use crate::bellbar::gadgets::num::AllocatedNum;
+use crate::bellbar::util_cs::bench_cs::BenchCS;
+use crate::bellbar::{Circuit, ConstraintSystem, SynthesisError};
 use crate::poseidon::{Arity, PoseidonConstants};
-use bellperson::gadgets::num::AllocatedNum;
-use bellperson::util_cs::bench_cs::BenchCS;
-use bellperson::{Circuit, ConstraintSystem, SynthesisError};
 use blstrs::Scalar as Fr;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use ff::Field;

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.7.1"
 ff = { workspace = true }
 generic-array = { workspace = true }
 log = { workspace = true }
-neptune = { path = "../", default-features = false, features = ["arity8", "arity11", "bls", "pasta"] }
+neptune = { path = "../", default-features = false, features = ["bellperson", "arity8", "arity11", "bls", "pasta"] }
 pasta_curves = { workspace = true, features = ["gpu"] }
 structopt = { version = "0.3", default-features = false }
 

--- a/src/bellbar.rs
+++ b/src/bellbar.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "bellperson")]
+pub use bellperson::*;
+
+#[cfg(not(feature = "bellperson"))]
+pub use bellpepper::*;

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,15 +1,15 @@
 /// Implement the legacy Poseidon hash circuit, retained for backwards compatibility with extant trusted setups.
 use std::ops::{AddAssign, MulAssign};
 
+use crate::bellbar::gadgets::boolean::Boolean;
+use crate::bellbar::gadgets::num;
+use crate::bellbar::gadgets::num::AllocatedNum;
+use crate::bellbar::{ConstraintSystem, LinearCombination, SynthesisError};
 use crate::circuit2::poseidon_hash_allocated;
 use crate::hash_type::HashType;
 use crate::matrix::Matrix;
 use crate::mds::SparseMatrix;
 use crate::poseidon::{Arity, PoseidonConstants};
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::gadgets::num;
-use bellperson::gadgets::num::AllocatedNum;
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::{Field, PrimeField};
 use std::marker::PhantomData;
 
@@ -611,10 +611,10 @@ fn scalar_product<Scalar: PrimeField, CS: ConstraintSystem<Scalar>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bellbar::util_cs::test_cs::TestConstraintSystem;
+    use crate::bellbar::ConstraintSystem;
     use crate::poseidon::HashMode;
     use crate::{Poseidon, Strength};
-    use bellperson::util_cs::test_cs::TestConstraintSystem;
-    use bellperson::ConstraintSystem;
     use blstrs::Scalar as Fr;
     use generic_array::typenum;
     use rand::SeedableRng;

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -1,14 +1,14 @@
 /// The `circuit2` module implements the optimal Poseidon hash circuit.
 use std::ops::{AddAssign, MulAssign};
 
+use crate::bellbar::gadgets::boolean::Boolean;
+use crate::bellbar::gadgets::num::{self, AllocatedNum};
+use crate::bellbar::gadgets::test::TestConstraintSystem;
+use crate::bellbar::{ConstraintSystem, LinearCombination, SynthesisError};
 use crate::hash_type::HashType;
 use crate::matrix::Matrix;
 use crate::mds::SparseMatrix;
 use crate::poseidon::{Arity, PoseidonConstants};
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::gadgets::num::{self, AllocatedNum};
-use bellperson::gadgets::test::TestConstraintSystem;
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::{Field, PrimeField};
 use std::marker::PhantomData;
 
@@ -693,10 +693,10 @@ fn scalar_product<Scalar: PrimeField, CS: ConstraintSystem<Scalar>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bellbar::util_cs::test_cs::TestConstraintSystem;
+    use crate::bellbar::ConstraintSystem;
     use crate::poseidon::HashMode;
     use crate::{Poseidon, Strength};
-    use bellperson::util_cs::test_cs::TestConstraintSystem;
-    use bellperson::ConstraintSystem;
     use blstrs::Scalar as Fr;
     use generic_array::typenum;
     use rand::SeedableRng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ compile_error!("The `strengthened` feature needs the `cuda` and/or `opencl` feat
 ))]
 compile_error!("The `cuda` and `opencl` features need the `bls` and/or `pasta` feature to be set");
 
+// Custom re-export of an arithmetization library : bellperson or bellpepper
+pub mod bellbar;
+
 /// Poseidon circuit
 pub mod circuit;
 pub mod circuit2;

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -1,3 +1,6 @@
+use crate::bellbar::gadgets::boolean::Boolean;
+use crate::bellbar::gadgets::num::{self, AllocatedNum};
+use crate::bellbar::{ConstraintSystem, LinearCombination, Namespace, SynthesisError};
 use crate::circuit2::{self, Elt, PoseidonCircuit2};
 use crate::hash_type::HashType;
 use crate::matrix::Matrix;
@@ -8,9 +11,6 @@ use crate::sponge::{
     vanilla::{Direction, Mode, SpongeTrait},
 };
 use crate::Strength;
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::gadgets::num::{self, AllocatedNum};
-use bellperson::{ConstraintSystem, LinearCombination, Namespace, SynthesisError};
 use ff::{Field, PrimeField};
 use std::collections::VecDeque;
 use std::marker::PhantomData;
@@ -236,7 +236,7 @@ mod tests {
     use super::*;
     use crate::sponge::vanilla::Sponge;
 
-    use bellperson::{util_cs::test_cs::TestConstraintSystem, Circuit};
+    use crate::bellbar::{util_cs::test_cs::TestConstraintSystem, Circuit};
     use blstrs::Scalar as Fr;
     use generic_array::typenum;
     use rand::{Rng, SeedableRng};


### PR DESCRIPTION
Hides bellperson / bellpepper behind a "bellbar" re-export which nature is controlled by the "groth16" feature.
Breaking change: those who want to stay on bellperson have to activate this non-default feature.