### PR TITLE
refactor: Refactor to eliminate implied lifetimes across multiple files

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -8,4 +8,5 @@ xclippy = [
     "clippy", "--all-targets", "--",
     "-Wclippy::all",
     "-Wclippy::disallowed_methods",
+    "-Wrust_2018_idioms",
 ]

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ impl From<ec_gpu_gen::EcError> for Error {
 impl error::Error for Error {}
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Error::FullBuffer => write!(
                 f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub enum Strength {
 }
 
 impl fmt::Display for Strength {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Standard => write!(f, "standard"),
             Self::Strengthened => write!(f, "strengthened"),

--- a/src/poseidon_alt.rs
+++ b/src/poseidon_alt.rs
@@ -11,7 +11,7 @@ use ff::PrimeField;
 /// This code path implements a naive and evidently correct poseidon hash.
 
 /// The returned element is the second poseidon element, the first is the arity tag.
-pub fn hash_correct<F, A>(p: &mut Poseidon<F, A>) -> F
+pub fn hash_correct<F, A>(p: &mut Poseidon<'_, F, A>) -> F
 where
     F: PrimeField,
     A: Arity<F>,
@@ -37,7 +37,7 @@ where
     p.elements[1]
 }
 
-pub fn full_round<F, A>(p: &mut Poseidon<F, A>)
+pub fn full_round<F, A>(p: &mut Poseidon<'_, F, A>)
 where
     F: PrimeField,
     A: Arity<F>,
@@ -70,7 +70,7 @@ where
 }
 
 /// The partial round is the same as the full round, with the difference that we apply the S-Box only to the first bitflags poseidon leaf.
-pub fn partial_round<F, A>(p: &mut Poseidon<F, A>)
+pub fn partial_round<F, A>(p: &mut Poseidon<'_, F, A>)
 where
     F: PrimeField,
     A: Arity<F>,
@@ -93,7 +93,7 @@ where
 /// Comments reference notation also expanded in matrix.rs and help clarify the relationship between
 /// our optimizations and those described in the paper.
 
-pub fn hash_optimized_dynamic<F, A>(p: &mut Poseidon<F, A>) -> F
+pub fn hash_optimized_dynamic<F, A>(p: &mut Poseidon<'_, F, A>) -> F
 where
     F: PrimeField,
     A: Arity<F>,
@@ -119,7 +119,7 @@ where
 }
 
 pub fn full_round_dynamic<F, A>(
-    p: &mut Poseidon<F, A>,
+    p: &mut Poseidon<'_, F, A>,
     add_current_round_keys: bool,
     absorb_next_round_keys: bool,
 ) where
@@ -214,7 +214,7 @@ pub fn full_round_dynamic<F, A>(
     p.product_mds();
 }
 
-pub fn partial_round_dynamic<F, A>(p: &mut Poseidon<F, A>)
+pub fn partial_round_dynamic<F, A>(p: &mut Poseidon<'_, F, A>)
 where
     F: PrimeField,
     A: Arity<F>,
@@ -228,7 +228,7 @@ where
 
 /// For every leaf, add the round constants with index defined by the constants offset, and increment the
 /// offset.
-fn add_round_constants<F, A>(p: &mut Poseidon<F, A>)
+fn add_round_constants<F, A>(p: &mut Poseidon<'_, F, A>)
 where
     F: PrimeField,
     A: Arity<F>,

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -71,7 +71,7 @@ where
         {
             type Value = PoseidonConstants<F, A>;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("struct PoseidonConstants")
             }
 


### PR DESCRIPTION
- Introduce explicit anonymous lifetime specifiers to functions across multiple files, bumping us to rust-2018
- see https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#elided-lifetimes-in-paths
- make rust_2018_idioms a mandatory lint