### PR TITLE
refactor: Set up a stricter xclippy

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -7,6 +7,8 @@
 xclippy = [
     "clippy", "--all-targets", "--",
     "-Wclippy::all",
+    "-Wclippy::cast_lossless",
     "-Wclippy::disallowed_methods",
     "-Wrust_2018_idioms",
+    "-Wunused_qualifications",
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 /scratch
 
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "rust-analyzer.check.features": null
-}

--- a/benches/hash.rs
+++ b/benches/hash.rs
@@ -138,8 +138,8 @@ criterion_group! {
 
     config = Criterion::default();
 
-    targets = bench_hash_bls::<typenum::U2>, bench_hash_bls::<typenum::U4>,
-    bench_hash_bls::<typenum::U8>, bench_hash_bls::<typenum::U11>
+    targets = bench_hash_bls::<U2>, bench_hash_bls::<U4>,
+    bench_hash_bls::<U8>, bench_hash_bls::<U11>
 }
 
 fn bench_bls_and_pasta_fields_for_arity<A>(c: &mut Criterion)

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,11 +15,11 @@ pub enum ClError {
 }
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
-pub type ClResult<T> = std::result::Result<T, ClError>;
+pub type ClResult<T> = Result<T, ClError>;
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
 impl fmt::Display for ClError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             ClError::DeviceNotFound => write!(f, "Device not found."),
             ClError::PlatformNotFound => write!(f, "Platform not found."),

--- a/src/hash_type.rs
+++ b/src/hash_type.rs
@@ -14,7 +14,7 @@ use crate::{Arity, Strength};
 use ff::PrimeField;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "F: PrimeField + Serialize, A: Arity<F>",
     deserialize = "F: PrimeField + Deserialize<'de>, A: Arity<F>"
@@ -60,18 +60,17 @@ impl<F: PrimeField, A: Arity<F>> HashType<F, A> {
     /// is sound.
     pub const fn is_supported(&self) -> bool {
         match self {
-            HashType::MerkleTree => true,
-            HashType::MerkleTreeSparse(_) => false,
-            HashType::VariableLength => false,
-            HashType::ConstantLength(_) => true,
-            HashType::Encryption => true,
-            HashType::Custom(_) => true,
-            HashType::Sponge => true,
+            HashType::MerkleTreeSparse(_) | HashType::VariableLength => false,
+            HashType::MerkleTree
+            | HashType::ConstantLength(_)
+            | HashType::Encryption
+            | HashType::Custom(_)
+            | HashType::Sponge => true,
         }
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CType<F: PrimeField, A: Arity<F>> {
     Arbitrary(u64),
     // See: https://github.com/bincode-org/bincode/issues/424
@@ -197,9 +196,9 @@ mod tests {
         assert_eq!(expected_standard_sponge, standard_sponge);
 
         let mut all_tags_set = HashSet::new();
-        all_tags.iter().for_each(|x| {
+        for x in all_tags.iter() {
             let _ = all_tags_set.insert(x.to_repr());
-        });
+        }
 
         // Cardinality of set and vector are the same,
         // hence no tag is duplicated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub(crate) const TEST_SEED: [u8; 16] = [
     0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc, 0xe5,
 ];
 
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Strength {
     Standard,
     Strengthened,
@@ -177,7 +177,7 @@ fn round_constants<F: PrimeField>(arity: usize, strength: &Strength) -> Vec<F> {
 
     let fr_num_bits = F::NUM_BITS;
     let field_size = {
-        assert!(fr_num_bits <= std::u16::MAX as u32);
+        assert!(fr_num_bits <= u32::from(std::u16::MAX));
         // It's safe to convert to u16 for compatibility with other types.
         fr_num_bits as u16
     };

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -498,10 +498,10 @@ mod tests {
         let some_vec = vec![six, five, four];
 
         // M^-1(S)
-        let inverse_applied = super::apply_matrix(&m_inv, &some_vec);
+        let inverse_applied = apply_matrix(&m_inv, &some_vec);
 
         // M(M^-1(S))
-        let m_applied_after_inverse = super::apply_matrix(&m, &inverse_applied);
+        let m_applied_after_inverse = apply_matrix(&m, &inverse_applied);
 
         // S = M(M^-1(S))
         assert_eq!(

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -9,7 +9,7 @@ use crate::matrix::{
     apply_matrix, invert, is_identity, is_invertible, is_square, mat_mul, minor, transpose, Matrix,
 };
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MdsMatrices<F: PrimeField> {
     pub m: Matrix<F>,
     pub m_inv: Matrix<F>,
@@ -45,7 +45,7 @@ pub fn derive_mds_matrices<F: PrimeField>(m: Matrix<F>) -> MdsMatrices<F> {
 /// This means its first row and column are each dense, and the interior matrix
 /// (minor to the element in both the row and column) is the identity.
 /// We will pluralize this compact structure `sparse_matrixes` to distinguish from `sparse_matrices` from which they are created.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SparseMatrix<F: PrimeField> {
     /// `w_hat` is the first column of the M'' matrix. It will be directly multiplied (scalar product) with a row of state elements.
     pub w_hat: Vec<F>,
@@ -233,10 +233,10 @@ mod tests {
         }
 
         // M^-1 x M = I
-        assert!(matrix::is_identity(&matrix::mat_mul(&m_inv, &m).unwrap()));
+        assert!(is_identity(&mat_mul(&m_inv, &m).unwrap()));
 
         // M' x M'' = M
-        assert_eq!(m, matrix::mat_mul(&m_prime, &m_double_prime).unwrap());
+        assert_eq!(m, mat_mul(&m_prime, &m_double_prime).unwrap());
     }
 
     #[test]
@@ -245,7 +245,7 @@ mod tests {
     }
 
     fn test_swapping_aux(width: usize) {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         let MdsMatrices {
             m,
@@ -295,7 +295,7 @@ mod tests {
     }
 
     fn test_factor_to_sparse_matrices_aux(width: usize, n: usize) {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         let m = generate_mds::<Fr>(width);
         let m2 = m.clone();

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -54,7 +54,7 @@ impl_arity!(
 ///
 /// [`Poseidon`] accepts input `elements` set with length equal or less than [`Arity`].
 ///
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Poseidon<'a, F, A = U2>
 where
     F: PrimeField,
@@ -78,7 +78,7 @@ where
 /// and [`Arity`] as [`Poseidon`] instance that consumes it.
 ///
 /// See original [Poseidon paper](https://eprint.iacr.org/2019/458.pdf) for more details.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PoseidonConstants<F, A>
 where
     F: PrimeField,
@@ -100,7 +100,7 @@ where
     pub(crate) _a: PhantomData<A>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum HashMode {
     // The initial and correct version of the algorithm. We should preserve the ability to hash this way for reference
     // and to preserve confidence in our tests along thew way.
@@ -958,7 +958,7 @@ mod tests {
         let constants = PoseidonConstants::new();
         preimage[0] = <Fr as Field>::ONE;
 
-        let mut h = Poseidon::<Fr, typenum::U3>::new_with_preimage(&preimage, &constants);
+        let mut h = Poseidon::<Fr, U3>::new_with_preimage(&preimage, &constants);
 
         let mut h2 = h.clone();
         let result = h.hash();
@@ -973,13 +973,13 @@ mod tests {
     }
 
     fn hash_values_cases(strength: Strength) {
-        hash_values_aux::<typenum::U2>(strength);
-        hash_values_aux::<typenum::U4>(strength);
-        hash_values_aux::<typenum::U8>(strength);
-        hash_values_aux::<typenum::U11>(strength);
-        hash_values_aux::<typenum::U16>(strength);
-        hash_values_aux::<typenum::U24>(strength);
-        hash_values_aux::<typenum::U36>(strength);
+        hash_values_aux::<U2>(strength);
+        hash_values_aux::<U4>(strength);
+        hash_values_aux::<U8>(strength);
+        hash_values_aux::<U11>(strength);
+        hash_values_aux::<U16>(strength);
+        hash_values_aux::<U24>(strength);
+        hash_values_aux::<U36>(strength);
     }
 
     /// Simple test vectors to ensure results don't change unintentionally in development.

--- a/src/proteus/gpu.rs
+++ b/src/proteus/gpu.rs
@@ -43,7 +43,7 @@ impl<T> cuda::KernelArgument for Buffer<T> {
 
 #[cfg(feature = "opencl")]
 impl<T> opencl::KernelArgument for Buffer<T> {
-    fn push(&self, kernel: &mut opencl::Kernel) {
+    fn push(&self, kernel: &mut opencl::Kernel<'_>) {
         match self {
             #[cfg(feature = "cuda")]
             Self::Cuda(_) => unreachable!(),

--- a/src/round_constants.rs
+++ b/src/round_constants.rs
@@ -38,7 +38,7 @@ pub fn generate_constants<F: PrimeField>(
     if n_bytes != 32 {
         unimplemented!("neptune currently supports 32-byte fields exclusively");
     }
-    assert_eq!((field_size as f32 / 8.0).ceil() as usize, n_bytes);
+    assert_eq!((f32::from(field_size) / 8.0).ceil() as usize, n_bytes);
 
     let num_constants = (r_f + r_p) * t;
     let mut init_sequence: Vec<bool> = Vec::new();

--- a/src/sponge/api.rs
+++ b/src/sponge/api.rs
@@ -10,7 +10,7 @@ pub enum Error {
     ParameterUsageMismatch,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SpongeOp {
     Absorb(u32),
     Squeeze(u32),
@@ -84,7 +84,7 @@ impl Hasher {
         self.x_i = self.x_i.overflowing_mul(self.x).0;
         self.state = self
             .state
-            .overflowing_add(self.x_i.overflowing_mul(a as u128).0)
+            .overflowing_add(self.x_i.overflowing_mul(u128::from(a)).0)
             .0;
     }
 
@@ -105,8 +105,7 @@ impl SpongeOp {
 
     pub const fn count(&self) -> u32 {
         match self {
-            Self::Absorb(n) => *n,
-            Self::Squeeze(n) => *n,
+            Self::Absorb(n) | Self::Squeeze(n) => *n,
         }
     }
 

--- a/src/sponge/vanilla.rs
+++ b/src/sponge/vanilla.rs
@@ -509,7 +509,7 @@ mod tests {
 
     #[test]
     fn test_simplex() {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         // Exercise simplex sponges with eventual size less, equal to, and greater to rate.
         for size in 2..10 {
@@ -550,7 +550,7 @@ mod tests {
 
     #[test]
     fn test_duplex_consistency() {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         // Exercise duplex sponges with eventual size less, equal to, and greater to rate.
         for size in 4..10 {


### PR DESCRIPTION
Activates lints:
-Wunused_qualifications,
-Wclippy::cast_lossless,

Also cleans up:
-Wclippy::derive_partial_eq_without_eq