### PR TITLE
chore: Propagate `portable` feature in cargo configurations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ strengthened = []
 # The supported fields for Poseidon running on the GPU are specified at compile-time.
 bls = ["blstrs/gpu"]
 pasta = ["pasta_curves/gpu"]
+portable = ["blstrs/portable"]
 
 [workspace]
 resolver = "2"

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -25,3 +25,4 @@ structopt = { version = "0.3", default-features = false }
 default = ["opencl"]
 cuda = ["neptune/cuda", "ec-gpu-gen/cuda"]
 opencl = ["neptune/opencl", "ec-gpu-gen/opencl"]
+portable = ["blstrs/portable"]


### PR DESCRIPTION
- Propagated a new `portable` feature across relevant crates and libraries, which toggles the same feature in blstrs,
- Updated the `Cargo.toml` for `blstrs` and `gbench` to include the new `portable` feature option.