### PR TITLE
refactor: Simplify GPU features and dependencies in Cargo.toml

### DIFF
--- a/.github/workflows/check-downstream-compiles.yml
+++ b/.github/workflows/check-downstream-compiles.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   check-arecibo-compiles:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: buildjet-8vcpu-ubuntu-2204
     env:
       RUSTFLAGS: -D warnings
     steps:
@@ -32,6 +32,7 @@ jobs:
       with:
         repository: lurk-lab/arecibo
         path: ${{ github.workspace }}/arecibo
+        ref: "dev"
         submodules: recursive
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,9 @@ incremental = false
 codegen-units = 1
 
 [features]
-default = []
-cuda = ["ec-gpu-gen/cuda", "ec-gpu", "pasta_curves/gpu"]
-opencl = ["ec-gpu-gen/opencl", "ec-gpu", "pasta_curves/gpu"]
+default = ["bls", "pasta"]
+cuda = ["ec-gpu-gen/cuda", "ec-gpu"]
+opencl = ["ec-gpu-gen/opencl", "ec-gpu"]
 # The supported arities for Poseidon running on the GPU are specified at compile-time.
 arity2 = []
 arity4 = []


### PR DESCRIPTION
While the computation of Neptune on the GPU is driven by the cuda and the opencl features, the bls/pasta features only drive the import of a modest amount of boilerplate code for ETL of GPU inputs and moduli in curve/field arithmetic:
- https://github.com/search?q=repo%3Afilecoin-project%2Fblstrs+%23%5Bcfg%28feature+%3D+%22gpu%22%29%5D&type=code
- https://github.com/search?q=repo%3Azcash%2Fpasta_curves+%23%5Bcfg%28feature+%3D+%22gpu%22%29%5D&type=code

This enables this code import by default, facilitating imports in upstream libraries, because feature propagation is then not needed. The cost is size in the linked binary.

- Enabled the "gpu" feature for "blstrs" and "pasta_curves" workspace dependencies by default in Cargo.toml file.