### PR TITLE
ci: fix CI run conditions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,12 +3,10 @@ name: Rust
 on:
   merge_group:
   push:
-    branches-ignore:
-      - "gh-readonly-queue/**"
-      - "main"
+    branches: [main, dev]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
+    branches: [main, dev]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
- Avoids running CI on push to a local branch,
- Amends Github actions workflow to include `dev` branch in push and pull_request events,