### PR TITLE
use non-deprecated getters for WitnessCS

### DIFF
--- a/src/circuit2_witness.rs
+++ b/src/circuit2_witness.rs
@@ -435,14 +435,14 @@ mod test {
                 let cs_inputs = cs.scalar_inputs();
                 let cs_aux = cs.scalar_aux();
 
-                let wcs_inputs = wcs.scalar_inputs();
-                let wcs_aux = wcs.scalar_aux();
+                let wcs_inputs = wcs.input_assignment();
+                let wcs_aux = wcs.aux_assignment();
 
                 assert_eq!(cs_aux.len(), wcs_aux.len());
 
-                assert_eq!(None, mismatch(&cs_inputs, &wcs_inputs));
+                assert_eq!(None, mismatch(&cs_inputs, wcs_inputs));
                 dbg!(&cs_aux[220..], &wcs_aux[220..]);
-                assert_eq!(None, mismatch(&cs_aux, &wcs_aux));
+                assert_eq!(None, mismatch(&cs_aux, wcs_aux));
 
                 let mut p = Poseidon::<Fr, A>::new_with_preimage(&fr_data, &constants);
                 let expected: Fr = p.hash_in_mode(HashMode::Correct);

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -527,12 +527,12 @@ mod tests {
             output
         };
         let cs_aux = cs.scalar_aux();
-        let wcs_aux = wcs.scalar_aux();
+        let wcs_aux = wcs.aux_assignment();
         let a = &cs_aux[300..320];
         let b = &wcs_aux[300..320];
         dbg!(cs_aux.len(), wcs_aux.len(), a, b);
 
-        assert_eq!(None, mismatch(&cs_aux, &wcs_aux));
+        assert_eq!(None, mismatch(&cs_aux, wcs_aux));
         assert!(cs.is_satisfied());
 
         let non_circuit_output = {


### PR DESCRIPTION
Following up on this comment: https://github.com/lurk-lab/lurk-rs/pull/840#issuecomment-1791475246