### PR TITLE
Neptune API maintenance

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -20,6 +20,7 @@ xclippy = [
     "-Wclippy::map_flatten",
     "-Wclippy::map_unwrap_or",
     "-Wclippy::needless_borrow",
+    "-Wclippy::needless_pass_by_value",
     "-Wclippy::unnecessary_wraps",
     "-Wclippy::trait_duplication_in_bounds",
     "-Wrust_2018_idioms",

--- a/.cargo/config
+++ b/.cargo/config
@@ -8,6 +8,7 @@ xclippy = [
     "-Wclippy::all",
     "-Wclippy::match_same_arms",
     "-Wclippy::cast_lossless",
+    "-Wclippy::checked_conversions",
     "-Wclippy::disallowed_methods",
     "-Wclippy::enum_glob_use",
     "-Wclippy::filter_map_next",
@@ -20,10 +21,10 @@ xclippy = [
     "-Wclippy::map_unwrap_or",
     "-Wclippy::needless_borrow",
     "-Wclippy::unnecessary_wraps",
-    "-Wclippy::checked_conversions",
     "-Wclippy::trait_duplication_in_bounds",
     "-Wrust_2018_idioms",
     "-Wtrivial_numeric_casts",
     "-Wunused_lifetimes",
     "-Wunused_qualifications",
+    "-Wunreachable_pub"
 ]

--- a/gbench/src/main.rs
+++ b/gbench/src/main.rs
@@ -78,7 +78,9 @@ fn bench_column_building<F: PrimeField + GpuName>(
 
     let computed_root = res[res.len() - 1];
 
-    let expected_root = builder.compute_uniform_tree_root(final_columns[0]).unwrap();
+    let expected_root = builder
+        .compute_uniform_tree_root(&final_columns[0])
+        .unwrap();
     let expected_size = builder.tree_size();
 
     assert_eq!(

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -540,6 +540,7 @@ pub fn mul_sum<CS: ConstraintSystem<Scalar>, Scalar: PrimeField>(
 }
 
 /// Calculates a * (b + to_add) — and enforces that constraint.
+#[deprecated(since = "12.1.0", note = "use mul_sum instead")]
 pub fn mul_pre_sum<CS: ConstraintSystem<Scalar>, Scalar: PrimeField>(
     mut cs: CS,
     a: &AllocatedNum<Scalar>,

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -637,6 +637,7 @@ pub fn mul_sum<CS: ConstraintSystem<Scalar>, Scalar: PrimeField>(
 }
 
 /// Calculates a * (b + to_add) — and enforces that constraint.
+#[deprecated(since = "12.1.0", note = "use mul_sum instead")]
 pub fn mul_pre_sum<CS: ConstraintSystem<Scalar>, Scalar: PrimeField>(
     mut cs: CS,
     a: &AllocatedNum<Scalar>,

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -222,7 +222,9 @@ mod tests {
 
         let computed_root = res[res.len() - 1];
 
-        let expected_root = builder.compute_uniform_tree_root(final_columns[0]).unwrap();
+        let expected_root = builder
+            .compute_uniform_tree_root(&final_columns[0])
+            .unwrap();
         let expected_size = builder.tree_builder.tree_size(0);
 
         assert_eq!(leaves, base.len());

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -135,10 +135,10 @@ where
     // without the cost of generating a full column tree.
     pub fn compute_uniform_tree_root(
         &mut self,
-        column: GenericArray<F, ColumnArity>,
+        column: &GenericArray<F, ColumnArity>,
     ) -> Result<F, Error> {
         // All the leaves will be the same.
-        let element = Poseidon::new_with_preimage(&column, &self.column_constants).hash();
+        let element = Poseidon::new_with_preimage(column, &self.column_constants).hash();
 
         self.tree_builder.compute_uniform_tree_root(element)
     }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -6,9 +6,9 @@ use ff::PrimeField;
 /// Matrix functions here are, at least for now, quick and dirty — intended only to support precomputation of poseidon optimization.
 
 /// Matrix represented as a Vec of rows, so that m[i][j] represents the jth column of the ith row in Matrix, m.
-pub type Matrix<T> = Vec<Vec<T>>;
+pub(crate) type Matrix<T> = Vec<Vec<T>>;
 
-pub fn rows<T>(matrix: &Matrix<T>) -> usize {
+pub(crate) fn rows<T>(matrix: &Matrix<T>) -> usize {
     matrix.len()
 }
 
@@ -57,7 +57,7 @@ fn scalar_vec_mul<F: PrimeField>(scalar: F, vec: &[F]) -> Vec<F> {
         .collect::<Vec<_>>()
 }
 
-pub fn mat_mul<F: PrimeField>(a: &Matrix<F>, b: &Matrix<F>) -> Option<Matrix<F>> {
+pub(crate) fn mat_mul<F: PrimeField>(a: &Matrix<F>, b: &Matrix<F>) -> Option<Matrix<F>> {
     if rows(a) != columns(b) {
         return None;
     };
@@ -85,7 +85,7 @@ fn vec_mul<F: PrimeField>(a: &[F], b: &[F]) -> F {
     })
 }
 
-pub fn vec_add<F: PrimeField>(a: &[F], b: &[F]) -> Vec<F> {
+pub(crate) fn vec_add<F: PrimeField>(a: &[F], b: &[F]) -> Vec<F> {
     a.iter()
         .zip(b.iter())
         .map(|(a, b)| {
@@ -96,7 +96,7 @@ pub fn vec_add<F: PrimeField>(a: &[F], b: &[F]) -> Vec<F> {
         .collect::<Vec<_>>()
 }
 
-pub fn vec_sub<F: PrimeField>(a: &[F], b: &[F]) -> Vec<F> {
+pub(crate) fn vec_sub<F: PrimeField>(a: &[F], b: &[F]) -> Vec<F> {
     a.iter()
         .zip(b.iter())
         .map(|(a, b)| {
@@ -108,7 +108,7 @@ pub fn vec_sub<F: PrimeField>(a: &[F], b: &[F]) -> Vec<F> {
 }
 
 /// Left-multiply a vector by a square matrix of same size: MV where V is considered a column vector.
-pub fn left_apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F> {
+pub(crate) fn left_apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F> {
     assert!(is_square(m), "Only square matrix can be applied to vector.");
     assert_eq!(
         rows(m),
@@ -129,7 +129,7 @@ pub fn left_apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F> {
 }
 
 /// Right-multiply a vector by a square matrix  of same size: VM where V is considered a row vector.
-pub fn apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F> {
+pub(crate) fn apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F> {
     assert!(is_square(m), "Only square matrix can be applied to vector.");
     assert_eq!(
         rows(m),
@@ -150,7 +150,7 @@ pub fn apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F> {
 }
 
 #[allow(clippy::needless_range_loop)]
-pub fn transpose<F: PrimeField>(matrix: &Matrix<F>) -> Matrix<F> {
+pub(crate) fn transpose<F: PrimeField>(matrix: &Matrix<F>) -> Matrix<F> {
     let size = rows(matrix);
     let mut new = Vec::with_capacity(size);
     for j in 0..size {
@@ -164,7 +164,7 @@ pub fn transpose<F: PrimeField>(matrix: &Matrix<F>) -> Matrix<F> {
 }
 
 #[allow(clippy::needless_range_loop)]
-pub fn make_identity<F: PrimeField>(size: usize) -> Matrix<F> {
+pub(crate) fn make_identity<F: PrimeField>(size: usize) -> Matrix<F> {
     let mut result = vec![vec![F::ZERO; size]; size];
     for i in 0..size {
         result[i][i] = F::ONE;
@@ -172,7 +172,7 @@ pub fn make_identity<F: PrimeField>(size: usize) -> Matrix<F> {
     result
 }
 
-pub fn kronecker_delta<F: PrimeField>(i: usize, j: usize) -> F {
+pub(crate) fn kronecker_delta<F: PrimeField>(i: usize, j: usize) -> F {
     if i == j {
         F::ONE
     } else {
@@ -180,7 +180,7 @@ pub fn kronecker_delta<F: PrimeField>(i: usize, j: usize) -> F {
     }
 }
 
-pub fn is_identity<F: PrimeField>(matrix: &Matrix<F>) -> bool {
+pub(crate) fn is_identity<F: PrimeField>(matrix: &Matrix<F>) -> bool {
     for i in 0..rows(matrix) {
         for j in 0..columns(matrix) {
             if matrix[i][j] != kronecker_delta(i, j) {
@@ -191,11 +191,11 @@ pub fn is_identity<F: PrimeField>(matrix: &Matrix<F>) -> bool {
     true
 }
 
-pub fn is_square<T>(matrix: &Matrix<T>) -> bool {
+pub(crate) fn is_square<T>(matrix: &Matrix<T>) -> bool {
     rows(matrix) == columns(matrix)
 }
 
-pub fn minor<F: PrimeField>(matrix: &Matrix<F>, i: usize, j: usize) -> Matrix<F> {
+pub(crate) fn minor<F: PrimeField>(matrix: &Matrix<F>, i: usize, j: usize) -> Matrix<F> {
     assert!(is_square(matrix));
     let size = rows(matrix);
     assert!(size > 0);

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -19,12 +19,12 @@ pub struct MdsMatrices<F: PrimeField> {
     pub m_double_prime: Matrix<F>,
 }
 
-pub fn create_mds_matrices<F: PrimeField>(t: usize) -> MdsMatrices<F> {
+pub(crate) fn create_mds_matrices<F: PrimeField>(t: usize) -> MdsMatrices<F> {
     let m = generate_mds(t);
     derive_mds_matrices(m)
 }
 
-pub fn derive_mds_matrices<F: PrimeField>(m: Matrix<F>) -> MdsMatrices<F> {
+pub(crate) fn derive_mds_matrices<F: PrimeField>(m: Matrix<F>) -> MdsMatrices<F> {
     let m_inv = invert(&m).unwrap(); // m is MDS so invertible.
     let m_hat = minor(&m, 0, 0);
     let m_hat_inv = invert(&m_hat).unwrap(); // If this returns None, then `mds_matrix` was not correctly generated.
@@ -90,7 +90,7 @@ impl<F: PrimeField> SparseMatrix<F> {
 //   - M'' is sparse and replaces M for the round.
 //   - The previous layer's M is then replaced by M x M' = M*.
 //   - M* is likewise factored into M*' and M*'', and the process continues.
-pub fn factor_to_sparse_matrixes<F: PrimeField>(
+pub(crate) fn factor_to_sparse_matrixes<F: PrimeField>(
     base_matrix: Matrix<F>,
     n: usize,
 ) -> (Matrix<F>, Vec<SparseMatrix<F>>) {
@@ -103,7 +103,7 @@ pub fn factor_to_sparse_matrixes<F: PrimeField>(
     (pre_sparse, sparse_matrixes)
 }
 
-pub fn factor_to_sparse_matrices<F: PrimeField>(
+pub(crate) fn factor_to_sparse_matrices<F: PrimeField>(
     base_matrix: Matrix<F>,
     n: usize,
 ) -> (Matrix<F>, Vec<Matrix<F>>) {

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -54,9 +54,18 @@ pub struct SparseMatrix<F: PrimeField> {
 }
 
 impl<F: PrimeField> SparseMatrix<F> {
+    #[allow(clippy::needless_pass_by_value)]
+    #[deprecated(
+        since = "12.1.0",
+        note = "Please use `SparseMatrix::new_from_ref` instead."
+    )]
     pub fn new(m_double_prime: Matrix<F>) -> Self {
-        assert!(Self::is_sparse_matrix(&m_double_prime));
-        let size = matrix::rows(&m_double_prime);
+        Self::new_from_ref(&m_double_prime)
+    }
+
+    pub fn new_from_ref(m_double_prime: &Matrix<F>) -> Self {
+        assert!(Self::is_sparse_matrix(m_double_prime));
+        let size = matrix::rows(m_double_prime);
 
         let w_hat = (0..size).map(|i| m_double_prime[i][0]).collect::<Vec<_>>();
         let v_rest = m_double_prime[0][1..].to_vec();
@@ -91,27 +100,27 @@ impl<F: PrimeField> SparseMatrix<F> {
 //   - The previous layer's M is then replaced by M x M' = M*.
 //   - M* is likewise factored into M*' and M*'', and the process continues.
 pub(crate) fn factor_to_sparse_matrixes<F: PrimeField>(
-    base_matrix: Matrix<F>,
+    base_matrix: &Matrix<F>,
     n: usize,
 ) -> (Matrix<F>, Vec<SparseMatrix<F>>) {
     let (pre_sparse, sparse_matrices) = factor_to_sparse_matrices(base_matrix, n);
     let sparse_matrixes = sparse_matrices
         .iter()
-        .map(|m| SparseMatrix::<F>::new(m.to_vec()))
+        .map(|m| SparseMatrix::<F>::new_from_ref(m))
         .collect::<Vec<_>>();
 
     (pre_sparse, sparse_matrixes)
 }
 
 pub(crate) fn factor_to_sparse_matrices<F: PrimeField>(
-    base_matrix: Matrix<F>,
+    base_matrix: &Matrix<F>,
     n: usize,
 ) -> (Matrix<F>, Vec<Matrix<F>>) {
     let (pre_sparse, mut all) =
         (0..n).fold((base_matrix.clone(), Vec::new()), |(curr, mut acc), _| {
             let derived = derive_mds_matrices(curr);
             acc.push(derived.m_double_prime);
-            let new = mat_mul(&base_matrix, &derived.m_prime).unwrap();
+            let new = mat_mul(base_matrix, &derived.m_prime).unwrap();
             (new, acc)
         });
     all.reverse();
@@ -300,7 +309,7 @@ mod tests {
         let m = generate_mds::<Fr>(width);
         let m2 = m.clone();
 
-        let (pre_sparse, mut sparse) = factor_to_sparse_matrices(m, n);
+        let (pre_sparse, mut sparse) = factor_to_sparse_matrices(&m, n);
         assert_eq!(n, sparse.len());
 
         let mut initial = Vec::with_capacity(width);
@@ -345,10 +354,10 @@ mod tests {
         let m = generate_mds::<Fr>(width);
         let m2 = m.clone();
 
-        let (pre_sparse, sparse_matrices) = factor_to_sparse_matrices(m, n);
+        let (pre_sparse, sparse_matrices) = factor_to_sparse_matrices(&m, n);
         assert_eq!(n, sparse_matrices.len());
 
-        let (pre_sparse2, sparse_matrixes) = factor_to_sparse_matrixes(m2, n);
+        let (pre_sparse2, sparse_matrixes) = factor_to_sparse_matrixes(&m2, n);
 
         assert_eq!(pre_sparse, pre_sparse2);
 

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -100,7 +100,7 @@ where
     pub(crate) _a: PhantomData<A>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum HashMode {
     // The initial and correct version of the algorithm. We should preserve the ability to hash this way for reference
     // and to preserve confidence in our tests along thew way.
@@ -269,7 +269,7 @@ where
         );
 
         let (pre_sparse_matrix, sparse_matrixes) =
-            factor_to_sparse_matrixes(mds_matrices.m.clone(), partial_rounds);
+            factor_to_sparse_matrixes(&mds_matrices.m, partial_rounds);
 
         // Ensure we have enough constants for the sbox rounds
         assert!(

--- a/src/poseidon_alt.rs
+++ b/src/poseidon_alt.rs
@@ -11,7 +11,7 @@ use ff::PrimeField;
 /// This code path implements a naive and evidently correct poseidon hash.
 
 /// The returned element is the second poseidon element, the first is the arity tag.
-pub fn hash_correct<F, A>(p: &mut Poseidon<'_, F, A>) -> F
+pub(crate) fn hash_correct<F, A>(p: &mut Poseidon<'_, F, A>) -> F
 where
     F: PrimeField,
     A: Arity<F>,
@@ -37,7 +37,7 @@ where
     p.elements[1]
 }
 
-pub fn full_round<F, A>(p: &mut Poseidon<'_, F, A>)
+pub(crate) fn full_round<F, A>(p: &mut Poseidon<'_, F, A>)
 where
     F: PrimeField,
     A: Arity<F>,
@@ -70,7 +70,7 @@ where
 }
 
 /// The partial round is the same as the full round, with the difference that we apply the S-Box only to the first bitflags poseidon leaf.
-pub fn partial_round<F, A>(p: &mut Poseidon<'_, F, A>)
+pub(crate) fn partial_round<F, A>(p: &mut Poseidon<'_, F, A>)
 where
     F: PrimeField,
     A: Arity<F>,
@@ -93,7 +93,7 @@ where
 /// Comments reference notation also expanded in matrix.rs and help clarify the relationship between
 /// our optimizations and those described in the paper.
 
-pub fn hash_optimized_dynamic<F, A>(p: &mut Poseidon<'_, F, A>) -> F
+pub(crate) fn hash_optimized_dynamic<F, A>(p: &mut Poseidon<'_, F, A>) -> F
 where
     F: PrimeField,
     A: Arity<F>,
@@ -118,7 +118,7 @@ where
     p.elements[1]
 }
 
-pub fn full_round_dynamic<F, A>(
+pub(crate) fn full_round_dynamic<F, A>(
     p: &mut Poseidon<'_, F, A>,
     add_current_round_keys: bool,
     absorb_next_round_keys: bool,
@@ -214,7 +214,7 @@ pub fn full_round_dynamic<F, A>(
     p.product_mds();
 }
 
-pub fn partial_round_dynamic<F, A>(p: &mut Poseidon<'_, F, A>)
+pub(crate) fn partial_round_dynamic<F, A>(p: &mut Poseidon<'_, F, A>)
 where
     F: PrimeField,
     A: Arity<F>,

--- a/src/proteus/sources.rs
+++ b/src/proteus/sources.rs
@@ -12,28 +12,28 @@ use pasta_curves::{Fp, Fq as Fv};
 
 use round_numbers::{round_numbers_base, round_numbers_strengthened};
 
-pub struct DerivedConstants {
-    pub arity: usize,
-    pub partial_rounds: usize,
-    pub width: usize,
-    pub sparse_matrix_size: usize,
-    pub full_half: usize,
-    pub sparse_offset: usize,
-    pub constants_elements: usize,
+pub(crate) struct DerivedConstants {
+    pub(crate) arity: usize,
+    pub(crate) partial_rounds: usize,
+    pub(crate) width: usize,
+    pub(crate) sparse_matrix_size: usize,
+    pub(crate) full_half: usize,
+    pub(crate) sparse_offset: usize,
+    pub(crate) constants_elements: usize,
 
     // Offsets
-    pub domain_tag_offset: usize,
-    pub round_keys_offset: usize,
-    pub mds_matrix_offset: usize,
-    pub pre_sparse_matrix_offset: usize,
-    pub sparse_matrixes_offset: usize,
-    pub w_hat_offset: usize,
-    pub v_rest_offset: usize,
+    pub(crate) domain_tag_offset: usize,
+    pub(crate) round_keys_offset: usize,
+    pub(crate) mds_matrix_offset: usize,
+    pub(crate) pre_sparse_matrix_offset: usize,
+    pub(crate) sparse_matrixes_offset: usize,
+    pub(crate) w_hat_offset: usize,
+    pub(crate) v_rest_offset: usize,
 }
 
 #[allow(clippy::suspicious_operation_groupings)]
 impl DerivedConstants {
-    pub fn new(arity: usize, full_rounds: usize, partial_rounds: usize) -> Self {
+    pub(crate) fn new(arity: usize, full_rounds: usize, partial_rounds: usize) -> Self {
         let sparse_count = partial_rounds;
         let width = arity + 1;
         let sparse_matrix_size = 2 * width - 1;
@@ -156,7 +156,7 @@ fn derive_constants(arity: usize) -> (DerivedConstants, DerivedConstants) {
 /// Returns the kernels source based on the set feature flags.
 ///
 /// Kernels for certain arities are enabled by feature flags.
-pub fn generate_program() -> SourceBuilder {
+pub(crate) fn generate_program() -> SourceBuilder {
     #[cfg(any(feature = "bls", feature = "pasta"))]
     let derived_constants = vec![
         #[cfg(feature = "arity2")]

--- a/src/round_constants.rs
+++ b/src/round_constants.rs
@@ -26,7 +26,7 @@ use ff::PrimeField;
 /// Following https://extgit.iaik.tugraz.at/krypto/hadeshash/blob/master/code/scripts/create_rcs_grain.sage
 /// The script was updated and can currently be found at:
 /// https://extgit.iaik.tugraz.at/krypto/hadeshash/blob/master/code/generate_parameters_grain.sage
-pub fn generate_constants<F: PrimeField>(
+pub(crate) fn generate_constants<F: PrimeField>(
     field: u8,
     sbox: u8,
     field_size: u16,
@@ -178,7 +178,7 @@ const fn bool_to_u8(bit: bool, offset: usize) -> u8 {
 
 /// Converts a slice of bools into their byte representation, in little endian.
 #[allow(dead_code)]
-pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
+pub(crate) fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
     bits.chunks(8)
         .map(|bits| {
             bool_to_u8(bits[7], 7)
@@ -196,7 +196,7 @@ pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    pub use blstrs::Scalar as Fr;
+    pub(crate) use blstrs::Scalar as Fr;
     use serde_json::Value;
     use std::fs::File;
     use std::io::{BufRead, BufReader};

--- a/src/sponge/api.rs
+++ b/src/sponge/api.rs
@@ -57,12 +57,12 @@ impl Default for Hasher {
 }
 
 impl Hasher {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Default::default()
     }
 
     /// Update hasher's current op to coalesce absorb/squeeze runs.
-    pub fn update_op(&mut self, op: SpongeOp) {
+    pub(crate) fn update_op(&mut self, op: SpongeOp) {
         if self.current_op.matches(op) {
             self.current_op = self.current_op.combine(op)
         } else {
@@ -80,7 +80,7 @@ impl Hasher {
         self.update(op_value);
     }
 
-    pub fn update(&mut self, a: u32) {
+    pub(crate) fn update(&mut self, a: u32) {
         self.x_i = self.x_i.overflowing_mul(self.x).0;
         self.state = self
             .state
@@ -88,7 +88,7 @@ impl Hasher {
             .0;
     }
 
-    pub fn finalize(&mut self, domain_separator: u32) -> u128 {
+    pub(crate) fn finalize(&mut self, domain_separator: u32) -> u128 {
         self.finish_op();
         self.update(domain_separator);
         self.state


### PR DESCRIPTION
- deprecates the duplicated, unused, subsumed`mul_pre_sum` in favor of `mul_sum`,
- deprecates an inefficient constructor for `SparseMatrix`,
- makes function visibility more clear & lints for `unreachable_pub` & `needless_pass_by_value`.