### PR TITLE
chore: remove no-longer-relevant forks on dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,12 +88,12 @@ members = [
 bellpepper-core = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev", default-features = false }
 bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev", default-features = false }
 blake2s_simd = "1.0.1"
-blstrs = { git="https://github.com/lurk-lab/blstrs.git", branch="dev"}
+blstrs = { version = "0.7.0" }
 ff = "0.13.0"
 generic-array = "0.14.7"
-pasta_curves = { git="https://github.com/lurk-lab/pasta_curves", branch="dev" }
-ec-gpu = { git="https://github.com/lurk-lab/ec-gpu", branch="dev" }
-ec-gpu-gen = { git="https://github.com/lurk-lab/ec-gpu", branch="dev" }
+pasta_curves = "0.5"
+ec-gpu = { version = "0.2.0" }
+ec-gpu-gen = { version = "0.7.0" }
 log = "0.4.19"
 byteorder = "1"
 


### PR DESCRIPTION
See :
- https://github.com/lurk-lab/arecibo/pull/277 and its integration into
- https://github.com/lurk-lab/arecibo/pull/279 (removing arecibo's pointer to blstrs, hence obsoleting the blstrs/ec-gpu forks)
- https://github.com/lurk-lab/arecibo/issues/332

> [!NOTE]
> The target of this PR is dev, not main, intentionally.