### PR TITLE
Switch bellpepper dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,8 @@ members = [
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
-bellpepper-core = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev", default-features = false }
-bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev", default-features = false }
+bellpepper-core = { version = "0.4.0", default-features = false }
+bellpepper = { git = "https://github.com/huitseeker/bellpepper", branch = "dev", default-features = false }
 blake2s_simd = "1.0.1"
 blstrs = { version = "0.7.0" }
 ff = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ members = [
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 bellpepper-core = { version = "0.4.0", default-features = false }
-bellpepper = { git = "https://github.com/huitseeker/bellpepper", branch = "dev", default-features = false }
+bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev", default-features = false }
 blake2s_simd = "1.0.1"
 blstrs = { version = "0.7.0" }
 ff = "0.13.0"


### PR DESCRIPTION
Companion PR of https://github.com/lurk-lab/bellpepper/pull/84

> [!IMPORTANT]
> The CI failure on cargo-deny is expected (on commits pointing at the branch of the above PR).
> To stamp, please wait for the commit pointing the bellpepper dependency back to https://github.com/lurk-rs/bellpepper@dev