### PR TITLE
Added test for sponge api & multiple cs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 /scratch
 
 .vscode/settings.json
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ blstrs = { workspace = true, optional = true }
 byteorder = { workspace = true }
 ec-gpu = { workspace = true, optional = true }
 ec-gpu-gen = { workspace = true, optional = true }
-ff ={ workspace = true }
+ff = { workspace = true }
 generic-array = { workspace = true }
 pasta_curves = { workspace = true, features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -80,13 +80,13 @@ abomonation = ["dep:abomonation", "dep:abomonation_derive"]
 [workspace]
 resolver = "2"
 members = [
-  "gbench",
+    "gbench",
 ]
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 bellpepper-core = { version = "0.4.0", default-features = false }
-bellpepper = { version = "0.4.0", default-features = false }
+bellpepper = { git = "https://github.com/lurk-lab/bellpepper.git", branch = "dev" }
 blake2s_simd = "1.0.1"
 blstrs = { version = "0.7.0" }
 ff = "0.13.0"

--- a/src/sponge/api.rs
+++ b/src/sponge/api.rs
@@ -261,9 +261,9 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
 #[cfg(test)]
 mod test {
     use bellpepper::util_cs::test_shape_cs::TestShapeCS;
+    use bellpepper_core::ConstraintSystem;
     use bellpepper_core::num::AllocatedNum;
     use bellpepper_core::test_cs::TestConstraintSystem;
-    use bellpepper_core::ConstraintSystem;
     use blstrs::Scalar as Fr;
     use ff::{Field, PrimeFieldBits};
     use generic_array::typenum::U24;
@@ -370,6 +370,7 @@ mod test {
             })
             .collect::<Vec<_>>();
 
+        // Values are `None`, we should get a None back
         let hash = sponge_cycle(&mut cs, &elts);
         assert!(hash[0].val().is_none());
 
@@ -384,6 +385,7 @@ mod test {
             })
             .collect::<Vec<_>>();
 
+        // We have values, we expect one in return
         let hash = sponge_cycle(&mut cs, &elts);
         assert_eq!(
             "Scalar(0x4d1f7863ee494536a938bd87d761a30828eeeeebfbc160117135dc6766f6e16c)",


### PR DESCRIPTION
## Goal

This PR introduces a test for `SpongeAPI` that test a full use of the API with multiple CS, `TestShapeCS` & `TestConstraintSystem`. The test is introduced to tackle some breaking changes that happened after https://github.com/lurk-lab/bellpepper/pull/88.

This PR will need https://github.com/lurk-lab/bellpepper/pull/91 to be merged in `bellpepper` before it can work. It will be needed to either depend on the `dev` branch or on a later release of `bellpepper`.